### PR TITLE
Add GameState provider

### DIFF
--- a/lib/game_state.dart
+++ b/lib/game_state.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/foundation.dart';
+import 'package:provider/provider.dart';
+
+/// Central game data managed via [ChangeNotifier].
+class GameState extends ChangeNotifier {
+  int mealsServed;
+  double cash;
+  int currentTier;
+  int prestigePoints;
+
+  GameState({
+    this.mealsServed = 0,
+    this.cash = 0,
+    this.currentTier = 0,
+    this.prestigePoints = 0,
+  });
+
+  /// Increment the number of meals served.
+  void incrementMeals([int amount = 1]) {
+    mealsServed += amount;
+    notifyListeners();
+  }
+
+  /// Add [amount] of in-game currency.
+  void addCash(double amount) {
+    cash += amount;
+    notifyListeners();
+  }
+
+  /// Spend [amount] if available.
+  void spendCash(double amount) {
+    if (cash >= amount) {
+      cash -= amount;
+      notifyListeners();
+    }
+  }
+
+  /// Update the current tier.
+  void setTier(int tier) {
+    currentTier = tier;
+    notifyListeners();
+  }
+
+  /// Increase prestige points.
+  void addPrestigePoints(int points) {
+    prestigePoints += points;
+    notifyListeners();
+  }
+}
+
+/// Global [ChangeNotifierProvider] for accessing and subscribing to
+/// the [GameState] throughout the widget tree.
+final ChangeNotifierProvider<GameState> gameStateProvider =
+    ChangeNotifierProvider<GameState>(create: (_) => GameState());

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
     sdk: flutter
 
   cupertino_icons: ^1.0.2
+  provider: ^6.0.5
 
 # The following adds the Cupertino Icons font to your application.
 # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- add ChangeNotifier-based `GameState` to manage meals, cash, tier, and prestige points
- expose `gameStateProvider` and state update methods
- include `provider` dependency

## Testing
- `dart format lib/game_state.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843e789bf9c83219ea01a223af279f0