### PR TITLE
Implement progression model and tier-based game state

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'models/game_state.dart';
 
 void main() => runApp(const MyApp());
 
@@ -22,7 +23,7 @@ class CounterPage extends StatefulWidget {
 }
 
 class _CounterPageState extends State<CounterPage> {
-  int count = 0;
+  final GameState game = GameState();
 
   @override
   Widget build(BuildContext context) {
@@ -32,10 +33,13 @@ class _CounterPageState extends State<CounterPage> {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Text('Meals served: $count'),
+            Text('Meals served: ${game.mealsServed}'),
+            Text('Current milestone: ${game.currentTier.name}'),
+            if (game.nextTier != null)
+              Text('Next: ${game.nextTier!.name} at ${game.nextTier!.unlockRequirement} meals'),
             const SizedBox(height: 16),
             ElevatedButton(
-              onPressed: () => setState(() => count++),
+              onPressed: () => setState(() => game.cookMeal()),
               child: const Text('Cook!'),
             ),
           ],

--- a/lib/models/game_state.dart
+++ b/lib/models/game_state.dart
@@ -1,0 +1,27 @@
+import 'progression.dart';
+
+class GameState {
+  int mealsServed;
+  int _tierIndex;
+
+  GameState({this.mealsServed = 0}) : _tierIndex = 0;
+
+  ProgressionTier get currentTier => progressionTiers[_tierIndex];
+
+  ProgressionTier? get nextTier =>
+      _tierIndex + 1 < progressionTiers.length
+          ? progressionTiers[_tierIndex + 1]
+          : null;
+
+  void cookMeal() {
+    mealsServed++;
+    _checkForTierUnlock();
+  }
+
+  void _checkForTierUnlock() {
+    final next = nextTier;
+    if (next != null && mealsServed >= next.unlockRequirement) {
+      _tierIndex++;
+    }
+  }
+}

--- a/lib/models/progression.dart
+++ b/lib/models/progression.dart
@@ -1,0 +1,44 @@
+class ProgressionTier {
+  final String name;
+  final int unlockRequirement; // meals served needed
+  final String reward;
+
+  const ProgressionTier({
+    required this.name,
+    required this.unlockRequirement,
+    required this.reward,
+  });
+}
+
+const List<ProgressionTier> progressionTiers = [
+  ProgressionTier(
+    name: 'Street Food',
+    unlockRequirement: 0,
+    reward: 'Base tapper + 3 upgrades',
+  ),
+  ProgressionTier(
+    name: 'Local Diner',
+    unlockRequirement: 100,
+    reward: 'Hire staff, new backgrounds',
+  ),
+  ProgressionTier(
+    name: 'Chain Store',
+    unlockRequirement: 1000,
+    reward: 'Idle income boosts + ad system',
+  ),
+  ProgressionTier(
+    name: 'Global Brand',
+    unlockRequirement: 5000,
+    reward: 'Prestige system, new tech upgrades',
+  ),
+  ProgressionTier(
+    name: 'Space Empire',
+    unlockRequirement: 20000,
+    reward: 'Intergalactic cuisine, absurd boosts',
+  ),
+  ProgressionTier(
+    name: 'Endgame',
+    unlockRequirement: 100000,
+    reward: 'Black hole catering, existential AI',
+  ),
+];


### PR DESCRIPTION
## Summary
- model each milestone tier in `lib/models/progression.dart`
- track progress and tier unlocks via new `GameState` class
- display current and upcoming milestones in the demo app

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843e7d13afc832195a30471c31ca2a3