### PR TITLE
Implement basic upgrade purchasing UI

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'models/upgrade.dart';
+import 'widgets/upgrade_panel.dart';
 
 void main() => runApp(const MyApp());
 
@@ -23,20 +25,52 @@ class CounterPage extends StatefulWidget {
 
 class _CounterPageState extends State<CounterPage> {
   int count = 0;
+  int coins = 0;
+  int perTap = 1;
+  late List<Upgrade> upgrades;
+
+  @override
+  void initState() {
+    super.initState();
+    upgrades = [
+      Upgrade(name: 'Better Stove', cost: 10, effect: 1),
+      Upgrade(name: 'Sous Chef', cost: 50, effect: 2),
+    ];
+  }
+
+  void _purchase(Upgrade upgrade) {
+    if (coins >= upgrade.cost && !upgrade.purchased) {
+      setState(() {
+        coins -= upgrade.cost;
+        perTap += upgrade.effect;
+        upgrade.purchased = true;
+      });
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Tap Tap Chef')),
-      body: Center(
+      body: Padding(
+        padding: const EdgeInsets.all(16),
         child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
           children: [
             Text('Meals served: $count'),
+            Text('Coins: $coins'),
             const SizedBox(height: 16),
             ElevatedButton(
-              onPressed: () => setState(() => count++),
-              child: const Text('Cook!'),
+              onPressed: () => setState(() {
+                count += perTap;
+                coins += perTap;
+              }),
+              child: Text('Cook (+$perTap)'),
+            ),
+            const SizedBox(height: 24),
+            UpgradePanel(
+              upgrades: upgrades,
+              currency: coins,
+              onPurchase: _purchase,
             ),
           ],
         ),

--- a/lib/models/upgrade.dart
+++ b/lib/models/upgrade.dart
@@ -1,0 +1,13 @@
+class Upgrade {
+  final String name;
+  final int cost;
+  final int effect; // how much perTap increases
+  bool purchased;
+
+  Upgrade({
+    required this.name,
+    required this.cost,
+    required this.effect,
+    this.purchased = false,
+  });
+}

--- a/lib/widgets/upgrade_panel.dart
+++ b/lib/widgets/upgrade_panel.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import '../models/upgrade.dart';
+
+class UpgradePanel extends StatelessWidget {
+  final List<Upgrade> upgrades;
+  final int currency;
+  final ValueChanged<Upgrade> onPurchase;
+
+  const UpgradePanel({
+    super.key,
+    required this.upgrades,
+    required this.currency,
+    required this.onPurchase,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: upgrades.map((u) {
+        return ListTile(
+          title: Text(u.name),
+          subtitle: Text('Cost: \$${u.cost} - Effect: +${u.effect} per tap'),
+          trailing: u.purchased
+              ? const Text('Purchased')
+              : ElevatedButton(
+                  onPressed: currency >= u.cost ? () => onPurchase(u) : null,
+                  child: const Text('Buy'),
+                ),
+        );
+      }).toList(),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- model upgrades with name, cost, and effect
- show an upgrade purchasing panel with buttons
- connect purchases to currency and tap power

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6843e7d468848321a520b5ff51155e8f