### PR TITLE
Add staff automation and hiring UI

### DIFF
--- a/lib/models/staff.dart
+++ b/lib/models/staff.dart
@@ -1,0 +1,15 @@
+enum StaffType { assistantChef, lineCook, robotChef }
+
+class Staff {
+  final String name;
+  final int cost;
+  final double tapsPerSecond;
+
+  const Staff({required this.name, required this.cost, required this.tapsPerSecond});
+}
+
+const Map<StaffType, Staff> staffOptions = {
+  StaffType.assistantChef: Staff(name: 'Assistant Chef', cost: 50, tapsPerSecond: 0.5),
+  StaffType.lineCook: Staff(name: 'Line Cook', cost: 200, tapsPerSecond: 2.0),
+  StaffType.robotChef: Staff(name: 'Robot Chef', cost: 1000, tapsPerSecond: 10.0),
+};


### PR DESCRIPTION
## Summary
- model staff types with automation speed
- generate passive taps from hired staff
- add modal for hiring staff in the UI

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843e7d599748321b442feb4d58fdec4