### PR TITLE
Add prestige system model

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'models/game_state.dart';
 
 void main() => runApp(const MyApp());
 
@@ -22,7 +23,7 @@ class CounterPage extends StatefulWidget {
 }
 
 class _CounterPageState extends State<CounterPage> {
-  int count = 0;
+  final GameState state = GameState();
 
   @override
   Widget build(BuildContext context) {
@@ -32,12 +33,22 @@ class _CounterPageState extends State<CounterPage> {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Text('Meals served: $count'),
+            Text('Meals served: ${state.mealsServed}'),
+            Text('Stage: ${state.currentMilestone}'),
+            Text('Prestige Points: ${state.prestige.points}'),
             const SizedBox(height: 16),
             ElevatedButton(
-              onPressed: () => setState(() => count++),
+              onPressed: () => setState(() => state.cook()),
               child: const Text('Cook!'),
             ),
+            if (state.atFinalMilestone)
+              Padding(
+                padding: const EdgeInsets.only(top: 16.0),
+                child: ElevatedButton(
+                  onPressed: () => setState(() => state.prestigeUp()),
+                  child: Text('Prestige (x${state.prestige.multiplier.toStringAsFixed(1)})'),
+                ),
+              ),
           ],
         ),
       ),

--- a/lib/models/game_state.dart
+++ b/lib/models/game_state.dart
@@ -1,0 +1,45 @@
+import 'prestige.dart';
+
+class GameState {
+  int mealsServed;
+  int milestoneIndex;
+  final Prestige prestige;
+
+  GameState({this.mealsServed = 0, this.milestoneIndex = 0, Prestige? prestige})
+      : prestige = prestige ?? Prestige();
+
+  static const List<String> milestones = [
+    'Street Food',
+    'Local Diner',
+    'Chain Store',
+    'Global Brand',
+    'Space Empire',
+    'Endgame'
+  ];
+
+  static const List<int> milestoneGoals = [10, 50, 150, 300, 600, 1000];
+
+  String get currentMilestone => milestones[milestoneIndex];
+
+  bool get atFinalMilestone => milestoneIndex >= milestones.length - 1;
+
+  void cook() {
+    mealsServed += prestige.multiplier.ceil();
+    if (!atFinalMilestone && mealsServed >= milestoneGoals[milestoneIndex]) {
+      milestoneIndex++;
+      mealsServed = 0;
+    }
+  }
+
+  void resetProgress() {
+    mealsServed = 0;
+    milestoneIndex = 0;
+  }
+
+  void prestigeUp() {
+    if (atFinalMilestone) {
+      prestige.gainPoint();
+      resetProgress();
+    }
+  }
+}

--- a/lib/models/prestige.dart
+++ b/lib/models/prestige.dart
@@ -1,0 +1,13 @@
+class Prestige {
+  int points;
+  final double baseMultiplier;
+  final double increment;
+
+  Prestige({this.points = 0, this.baseMultiplier = 1.0, this.increment = 0.5});
+
+  double get multiplier => baseMultiplier + points * increment;
+
+  void gainPoint() {
+    points += 1;
+  }
+}


### PR DESCRIPTION
## Summary
- add new `Prestige` model to manage permanent multipliers
- track milestones and progress in a `GameState` class
- update main example to demonstrate prestige flow

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843e7d894a083219699869292fbdcd9