### PR TITLE
Add persistent game storage

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'services/storage.dart';
 
 void main() => runApp(const MyApp());
 
@@ -23,6 +24,29 @@ class CounterPage extends StatefulWidget {
 
 class _CounterPageState extends State<CounterPage> {
   int count = 0;
+  final _storage = StorageService();
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final loaded = await _storage.loadGame();
+    setState(() => count = loaded);
+  }
+
+  Future<void> _increment() async {
+    setState(() => count++);
+    await _storage.saveGame(count);
+  }
+
+  @override
+  void dispose() {
+    _storage.saveGame(count);
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -35,7 +59,7 @@ class _CounterPageState extends State<CounterPage> {
             Text('Meals served: $count'),
             const SizedBox(height: 16),
             ElevatedButton(
-              onPressed: () => setState(() => count++),
+              onPressed: _increment,
               child: const Text('Cook!'),
             ),
           ],

--- a/lib/services/storage.dart
+++ b/lib/services/storage.dart
@@ -1,0 +1,34 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class StorageService {
+  static const _keyCount = 'count';
+  static const _keyTimestamp = 'timestamp';
+
+  /// Saves the current count and timestamp to local storage.
+  Future<void> saveGame(int count) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_keyCount, count);
+    await prefs.setInt(_keyTimestamp, DateTime.now().millisecondsSinceEpoch);
+  }
+
+  /// Loads the saved count and applies idle earnings based on the time elapsed.
+  /// [idleRate] determines how many meals are earned per second while offline.
+  Future<int> loadGame({int idleRate = 1}) async {
+    final prefs = await SharedPreferences.getInstance();
+    final savedCount = prefs.getInt(_keyCount) ?? 0;
+    final timestamp = prefs.getInt(_keyTimestamp);
+    int newCount = savedCount;
+
+    if (timestamp != null) {
+      final last = DateTime.fromMillisecondsSinceEpoch(timestamp);
+      final elapsed = DateTime.now().difference(last).inSeconds;
+      newCount += elapsed * idleRate;
+    }
+
+    // Persist the updated count and timestamp so idle earnings aren't
+    // repeatedly added on subsequent loads.
+    await prefs.setInt(_keyCount, newCount);
+    await prefs.setInt(_keyTimestamp, DateTime.now().millisecondsSinceEpoch);
+    return newCount;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
     sdk: flutter
 
   cupertino_icons: ^1.0.2
+  shared_preferences: ^2.2.2
 
 # The following adds the Cupertino Icons font to your application.
 # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- add shared_preferences to pubspec
- create a storage service for saving/loading game state
- persist counter state with idle earnings in main

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843e7d681088321b370ff9e650e794c