### PR TITLE
Expand storyline and advanced features

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ Inspired by **Egg, Inc.** and **Universal Paperclips**, Tap Tap Chef balances a 
 - **Tap to Cook** – Taps = meals served = cash.
 - **Upgrade Kitchen** – Faster production, better food.
 - **Hire Staff** – Automate income generation.
-- **Expand Reach** – From food trucks → restaurants → space diners.
+- **Expand Reach** – From food trucks → restaurants → space diners → multiverse cafeterias.
 - **Prestige** – "Universal Catering Contracts" to reset progress and gain permanent multipliers.
 
 ### Long-Term Progression:
 - **Research Tree** (Post-MVP): Unlock futuristic cooking tech.
+- **Time & Space Upgrades** (Post-MVP): Reach time warp kitchens and multiverse franchises.
 - **Narrative Beats** (Post-MVP): Satirical and existential reflections à la Universal Paperclips.
 - **Cosmetics + Customization** (Post-MVP): Chef skins, themed kitchens, food particles, etc.
 
@@ -81,8 +82,9 @@ Inspired by **Egg, Inc.** and **Universal Paperclips**, Tap Tap Chef balances a 
 2. [ ] Upgrade UI & backend model  
 3. [ ] Staff automation layer  
 4. [ ] Idle earning & save/load  
-5. [ ] MVP-ready restaurant progression  
+5. [ ] MVP-ready restaurant progression
 6. [ ] First prestige reset loop
+7. [ ] Prototype time-warp tiers
 
 ---
 

--- a/game_design_doc.md
+++ b/game_design_doc.md
@@ -63,6 +63,8 @@
 | Global Brand | Prestige system, new tech upgrades  | Sushi, Curry, Banh Mi     |
 | Space Empire | Intergalactic cuisine, absurd boosts| Moon cheese, Alien eggs   |
 | Endgame      | Black hole catering, existential AI | “Conceptual hunger”       |
+| Time Warp Kitchen | Temporal upgrades, time-loop menus | Chrono-chili |
+| Multiverse Franchise | Reality-hopping logistics | Schrödinger's soufflé |
 
 ---
 
@@ -74,6 +76,7 @@
 | Staff Tech   | Instant serve, Mood booster, Dual chefs   |
 | Restaurant   | Increase customer cap, Decor bonus        |
 | Prestige     | % earnings bonus, tap cooldowns, unlocks  |
+| Dimensional  | Time loops, multiverse delivery           |
 
 *Upgrade math will use exponential cost scaling + diminishing returns curves.*
 
@@ -159,7 +162,8 @@
 2. Build tap mechanic + base upgrades  
 3. Implement staff automation  
 4. Add simple save/load system  
-5. Structure prestige system  
+5. Structure prestige system
 6. Internal test build
+7. Prototype time-warp and multiverse tiers
 
 ---

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -47,6 +47,8 @@ class _CounterPageState extends State<CounterPage> {
     upgrades = [
       Upgrade(name: 'Better Stove', cost: 10, effect: 1),
       Upgrade(name: 'Sous Chef', cost: 50, effect: 2),
+      Upgrade(name: 'Quantum Oven', cost: 250, effect: 5),
+      Upgrade(name: 'Transdimensional Delivery', cost: 1000, effect: 10),
     ];
     _load();
     _timer = Timer.periodic(const Duration(seconds: 1), (_) => _tickPassive());

--- a/lib/models/game_state.dart
+++ b/lib/models/game_state.dart
@@ -14,10 +14,21 @@ class GameState {
     'Chain Store',
     'Global Brand',
     'Space Empire',
-    'Endgame'
+    'Endgame',
+    'Time Warp Kitchen',
+    'Multiverse Franchise'
   ];
 
-  static const List<int> milestoneGoals = [10, 50, 150, 300, 600, 1000];
+  static const List<int> milestoneGoals = [
+    10,
+    50,
+    150,
+    300,
+    600,
+    1000,
+    2000,
+    5000
+  ];
 
   String get currentMilestone => milestones[milestoneIndex];
 

--- a/lib/models/staff.dart
+++ b/lib/models/staff.dart
@@ -1,4 +1,4 @@
-enum StaffType { assistantChef, lineCook, robotChef }
+enum StaffType { assistantChef, lineCook, robotChef, timeChef, dimensionManager }
 
 class Staff {
   final String name;
@@ -12,4 +12,8 @@ const Map<StaffType, Staff> staffOptions = {
   StaffType.assistantChef: Staff(name: 'Assistant Chef', cost: 50, tapsPerSecond: 0.5),
   StaffType.lineCook: Staff(name: 'Line Cook', cost: 200, tapsPerSecond: 2.0),
   StaffType.robotChef: Staff(name: 'Robot Chef', cost: 1000, tapsPerSecond: 10.0),
+  StaffType.timeChef:
+      Staff(name: 'Time Traveler Chef', cost: 5000, tapsPerSecond: 50.0),
+  StaffType.dimensionManager:
+      Staff(name: 'Interdimensional Manager', cost: 20000, tapsPerSecond: 200.0),
 };


### PR DESCRIPTION
## Summary
- expand the README gameplay loop with multiverse scale
- extend design doc with time warp and multiverse tiers
- add new upgrades in the Flutter app
- add extra milestones and staff types for late‑game scaling

## Testing
- `dart` and `flutter` were not available so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68440091bf448321a0060fee25e98bc6