### PR TITLE
Add combo meter and Frenzy Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Inspired by **Egg, Inc.** and **Universal Paperclips**, Tap Tap Chef balances a 
 
 ### Basic Loop:
 - **Tap to Cook** – Taps = meals served = cash.
+- **Build Combos** – Rapid taps raise a combo meter for extra earnings.
+- **Frenzy Mode** – Max the meter for a short burst of huge profits.
 - **Upgrade Kitchen** – Faster production, better food.
 - **Hire Staff** – Automate income generation.
 - **Expand Reach** – From food trucks → restaurants → space diners → multiverse cafeterias.

--- a/game_design_doc.md
+++ b/game_design_doc.md
@@ -28,7 +28,9 @@
 ### 1. **Tapping & Income System**
 - Every tap = 1 meal served
 - Base cash per tap scales with dish tier
-- Combo multipliers for tap streaks (optional phase 2)
+- **Combo Meter:** rapid tapping builds a meter that multiplies earnings.
+- **Frenzy Mode:** maxing the meter triggers a short burst with screen shake,
+  flashy particles, and a large earnings boost.
 
 ### 2. **Kitchen Upgrades**
 | Upgrade        | Effect                        | Cost Type |


### PR DESCRIPTION
## Summary
- implement combo meter with Frenzy Mode in main.dart
- document the new feature in README and game design doc

## Testing
- `apt-get update`
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844cdc9d6e88321adeb71b2b82d97c4