### PR TITLE
Implement offline earnings popup

### DIFF
--- a/lib/services/storage.dart
+++ b/lib/services/storage.dart
@@ -1,5 +1,11 @@
 import 'package:shared_preferences/shared_preferences.dart';
 
+class OfflineLoadResult {
+  final int count;
+  final int earned;
+  OfflineLoadResult(this.count, this.earned);
+}
+
 class StorageService {
   static const _keyCount = 'count';
   static const _keyTimestamp = 'timestamp';
@@ -12,24 +18,26 @@ class StorageService {
   }
 
   /// Loads the saved count and applies idle earnings based on the time elapsed.
-  /// [idleRate] determines how many meals are earned per second while offline.
-  Future<int> loadGame({int idleRate = 1}) async {
+  /// [idleMultiplier] determines how many meals are earned per second while offline.
+  Future<OfflineLoadResult> loadGame({double idleMultiplier = 1.0}) async {
     final prefs = await SharedPreferences.getInstance();
     final savedCount = prefs.getInt(_keyCount) ?? 0;
     final timestamp = prefs.getInt(_keyTimestamp);
     int newCount = savedCount;
+    int earned = 0;
 
     if (timestamp != null) {
       final last = DateTime.fromMillisecondsSinceEpoch(timestamp);
       final elapsed = DateTime.now().difference(last).inSeconds;
-      newCount += elapsed * idleRate;
+      earned = (elapsed * idleMultiplier).floor();
+      newCount += earned;
     }
 
     // Persist the updated count and timestamp so idle earnings aren't
     // repeatedly added on subsequent loads.
     await prefs.setInt(_keyCount, newCount);
     await prefs.setInt(_keyTimestamp, DateTime.now().millisecondsSinceEpoch);
-    return newCount;
+    return OfflineLoadResult(newCount, earned);
   }
 
   /// Clears all saved progress so the game starts fresh.


### PR DESCRIPTION
## Summary
- add `OfflineLoadResult` data class
- extend `StorageService.loadGame` to return offline earnings
- play an animated popup with a rewarded-ad option for offline cash
- include new offline cash multiplier set to 0.0025

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844d0f600fc8321a8f24ee2564d20c5