### PR TITLE
Add pulsing effect for purchasable actions

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -394,14 +394,17 @@ class _CounterPageState extends State<CounterPage> {
               subtitle: Text(
                 'Cost: ${staff.cost} \u2014 ${staff.tapsPerSecond} taps/s',
               ),
-              trailing: ElevatedButton(
-                onPressed: affordable
-                    ? () {
-                        Navigator.pop(context);
-                        _hireStaff(type);
-                      }
-                    : null,
-                child: const Text('Hire'),
+              trailing: Pulse(
+                active: affordable,
+                child: ElevatedButton(
+                  onPressed: affordable
+                      ? () {
+                          Navigator.pop(context);
+                          _hireStaff(type);
+                        }
+                      : null,
+                  child: const Text('Hire'),
+                ),
               ),
             );
           }).toList(),

--- a/lib/widgets/upgrade_panel.dart
+++ b/lib/widgets/upgrade_panel.dart
@@ -1,6 +1,75 @@
 import 'package:flutter/material.dart';
 import '../models/upgrade.dart';
 
+/// Simple pulsing effect to draw attention to actionable buttons.
+class Pulse extends StatefulWidget {
+  final Widget child;
+  final bool active;
+
+  const Pulse({required this.child, required this.active});
+
+  @override
+  State<Pulse> createState() => _PulseState();
+}
+
+class _PulseState extends State<Pulse> with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 800),
+    );
+    if (widget.active) {
+      _controller.repeat(reverse: true);
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant Pulse oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.active && !_controller.isAnimating) {
+      _controller.repeat(reverse: true);
+    } else if (!widget.active && _controller.isAnimating) {
+      _controller.stop();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _controller,
+      child: widget.child,
+      builder: (context, child) {
+        final scale = 1 + 0.05 * _controller.value;
+        final glow = 6 * _controller.value;
+        return Transform.scale(
+          scale: scale,
+          child: Container(
+            decoration: BoxDecoration(
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.yellow.withOpacity(0.6 * _controller.value),
+                  blurRadius: glow,
+                ),
+              ],
+            ),
+            child: child,
+          ),
+        );
+      },
+    );
+  }
+}
+
 class UpgradePanel extends StatelessWidget {
   final List<Upgrade> upgrades;
   final int currency;
@@ -22,9 +91,12 @@ class UpgradePanel extends StatelessWidget {
           subtitle: Text('Cost: \$${u.cost} - Effect: +${u.effect} per tap'),
           trailing: u.purchased
               ? const Text('Purchased')
-              : ElevatedButton(
-                  onPressed: currency >= u.cost ? () => onPurchase(u) : null,
-                  child: const Text('Buy'),
+              : Pulse(
+                  active: currency >= u.cost,
+                  child: ElevatedButton(
+                    onPressed: currency >= u.cost ? () => onPurchase(u) : null,
+                    child: const Text('Buy'),
+                  ),
                 ),
         );
       }).toList(),


### PR DESCRIPTION
## Summary
- give upgrade buttons a pulsing glow when affordable
- use the same effect for staff hire buttons
- expose a reusable `Pulse` widget via `upgrade_panel.dart`

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_68453fb05bec8321b9c53100e46c9405