### PR TITLE
Add bulk purchase options for upgrades and staff

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Inspired by **Egg, Inc.** and **Universal Paperclips**, Tap Tap Chef balances a 
 - **Special Customers** – Occasionally a VIP pops up. Tap them for mini-games or temporary boosts.
 - **Upgrade Kitchen** – Faster production, better food.
 - **Hire Staff** – Automate income generation.
+- **Bulk Buy Options** – Purchase 10, 100, or the max number of upgrades or staff at once.
 - **Expand Reach** – From food trucks → restaurants → space diners → multiverse cafeterias.
 - **Prestige** – "Universal Catering Contracts" to reset progress and gain permanent multipliers.
 

--- a/lib/models/upgrade.dart
+++ b/lib/models/upgrade.dart
@@ -1,13 +1,15 @@
 class Upgrade {
   final String name;
   final int cost;
-  final int effect; // how much perTap increases
-  bool purchased;
+  final int effect; // how much perTap increases per purchase
+
+  /// Number of times this upgrade has been purchased.
+  int owned;
 
   Upgrade({
     required this.name,
     required this.cost,
     required this.effect,
-    this.purchased = false,
+    this.owned = 0,
   });
 }

--- a/lib/widgets/upgrade_panel.dart
+++ b/lib/widgets/upgrade_panel.dart
@@ -73,7 +73,7 @@ class _PulseState extends State<Pulse> with SingleTickerProviderStateMixin {
 class UpgradePanel extends StatelessWidget {
   final List<Upgrade> upgrades;
   final int currency;
-  final ValueChanged<Upgrade> onPurchase;
+  final void Function(Upgrade, int) onPurchase;
 
   const UpgradePanel({
     super.key,
@@ -86,18 +86,41 @@ class UpgradePanel extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: upgrades.map((u) {
+        final bool affordable = currency >= u.cost;
+        final bool affordable10 = currency >= u.cost * 10;
+        final bool affordable100 = currency >= u.cost * 100;
+        final int maxAffordable = currency ~/ u.cost;
         return ListTile(
           title: Text(u.name),
-          subtitle: Text('Cost: \$${u.cost} - Effect: +${u.effect} per tap'),
-          trailing: u.purchased
-              ? const Text('Purchased')
-              : Pulse(
-                  active: currency >= u.cost,
-                  child: ElevatedButton(
-                    onPressed: currency >= u.cost ? () => onPurchase(u) : null,
-                    child: const Text('Buy'),
-                  ),
+          subtitle: Text(
+              'Cost: \$${u.cost} - Effect: +${u.effect} per tap - Owned: ${u.owned}'),
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Pulse(
+                active: affordable,
+                child: ElevatedButton(
+                  onPressed: affordable ? () => onPurchase(u, 1) : null,
+                  child: const Text('1'),
                 ),
+              ),
+              const SizedBox(width: 4),
+              ElevatedButton(
+                onPressed: affordable10 ? () => onPurchase(u, 10) : null,
+                child: const Text('10'),
+              ),
+              const SizedBox(width: 4),
+              ElevatedButton(
+                onPressed: affordable100 ? () => onPurchase(u, 100) : null,
+                child: const Text('100'),
+              ),
+              const SizedBox(width: 4),
+              ElevatedButton(
+                onPressed: maxAffordable > 0 ? () => onPurchase(u, maxAffordable) : null,
+                child: const Text('MAX'),
+              ),
+            ],
+          ),
         );
       }).toList(),
     );


### PR DESCRIPTION
## Summary
- allow upgrades to be purchased multiple times
- add bulk buy buttons for upgrades and staff
- update game logic to handle quantity purchases
- document bulk buy feature

## Testing
- `dart format lib` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684540b682f48321b76a331a6202d2f7