### PR TITLE
Add rewarded ad boost feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Inspired by **Egg, Inc.** and **Universal Paperclips**, Tap Tap Chef balances a 
 
 ---
 
-## 💰 Monetization Strategy (Post-MVP)
+## 💰 Monetization Strategy
 
-- **Rewarded Video Ads** (e.g., instant delivery, time skips)
+- **Rewarded Video Ads** – watch an ad to double earnings for 5 minutes or gain a lump-sum bonus
 - **IAPs for Boosts** (currency packs, chef multipliers)
 - **Cosmetics Store** (skins, themed backgrounds, effects)
 - **VIP Pass System** (premium prestige tree, bonus automation)

--- a/game_design_doc.md
+++ b/game_design_doc.md
@@ -87,10 +87,10 @@
 
 ## 💸 Monetization Plan
 
-### Free-to-Play (MVP Post-Launch)
+### Free-to-Play
 - Rewarded ads for:
-  - Instant cash
-  - Temporary 2x income
+  - Instant cash payouts
+  - Temporary 2x income (5-minute boost)
   - Rush orders
 
 ### IAPs
@@ -120,7 +120,7 @@
 | Save/load game state           | ✅        |
 | Prestige reset system          | ✅        |
 | 3–4 progression tiers          | ✅        |
-| Monetization (rewarded ads)   | ❌        |
+| Monetization (rewarded ads)   | ✅        |
 | IAP / cosmetics                | ❌        |
 | Sound/Music                    | ❌        |
 | Dialogue/Narration system     | ❌        |


### PR DESCRIPTION
## Summary
- implement temporary ad boost state and watch-ad dialog
- show countdown when ad boost is active
- include new rewarded ad button in UI
- document ad rewards in README and game design doc

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845422a88648321be67fa6367dea57a