### PR TITLE
Fix layout overflow

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -643,7 +643,8 @@ class _CounterPageState extends State<CounterPage> {
           children: [
             Padding(
               padding: const EdgeInsets.all(16),
-              child: Column(
+              child: SingleChildScrollView(
+                child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text('Meals served: ${game.mealsServed}'),
@@ -698,7 +699,8 @@ class _CounterPageState extends State<CounterPage> {
           ),
         ],
       ),
-          ),
+    ),
+  ),
           if (_specialVisible)
             Positioned(
               bottom: 80,


### PR DESCRIPTION
## Summary
- wrap main content in `SingleChildScrollView` so text doesn't overflow

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845449c6cfc83219c68344b3938bb7e