### PR TITLE
Switch to Riverpod for state management

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Inspired by **Egg, Inc.** and **Universal Paperclips**, Tap Tap Chef balances a 
 ## 📱 Tech Stack
 
 - **Flutter** for cross-platform mobile development (iOS & Android)
-- **Provider or Riverpod** for state management
+- **Riverpod** for state management
 - **Hive** or **Shared Preferences** for local save data
 - **Custom widget framework** for upgrade panels, tap animations, and progress bars
 - Optional: Flame engine (if visual FX becomes performance-heavy)

--- a/lib/game_state.dart
+++ b/lib/game_state.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/foundation.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-/// Central game data managed via [ChangeNotifier].
+/// Central game data managed via Riverpod using [ChangeNotifier].
 class GameState extends ChangeNotifier {
   int mealsServed;
   double cash;
@@ -51,4 +51,4 @@ class GameState extends ChangeNotifier {
 /// Global [ChangeNotifierProvider] for accessing and subscribing to
 /// the [GameState] throughout the widget tree.
 final ChangeNotifierProvider<GameState> gameStateProvider =
-    ChangeNotifierProvider<GameState>(create: (_) => GameState());
+    ChangeNotifierProvider<GameState>((ref) => GameState());

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'models/game_state.dart';
 import 'models/staff.dart';
@@ -71,7 +72,7 @@ const List<String> milestoneDialogues = [
   "The multiverse demands endless specials. Hope you're not out of ideas."
 ];
 
-void main() => runApp(const MyApp());
+void main() => runApp(const ProviderScope(child: MyApp()));
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
 
   cupertino_icons: ^1.0.2
   shared_preferences: ^2.2.2
-  provider: ^6.0.5
+  flutter_riverpod: ^2.4.0
   audioplayers: ^5.2.1
 
 # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
## Summary
- replace Provider with Riverpod
- wrap app in `ProviderScope`
- adjust README tech stack section

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68454e779d6c832194842a1c0f90427e