### PR TITLE
Enable Flutter release run option

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,6 +7,13 @@
       "request": "launch",
       "program": "lib/main.dart",
       "flutterMode": "debug"
+    },
+    {
+      "name": "Run TapTapChef (Release)",
+      "type": "dart",
+      "request": "launch",
+      "program": "lib/main.dart",
+      "flutterMode": "release"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -106,5 +106,9 @@ This repository now includes a minimal Flutter application. To run it locally:
    ```bash
    flutter run
    ```
+   For an optimized build that installs like a production app, use release mode:
+   ```bash
+   flutter run --release
+   ```
 
 The starter app tracks how many meals you've cooked each time you tap the **Cook!** button.


### PR DESCRIPTION
## Summary
- add release launch configuration for VS Code
- document how to run Flutter in release mode

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684550e257788321b098c312f607afc3