### PR TITLE
Fix UI interactions and upgrade layout

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -702,10 +702,12 @@ class _CounterPageState extends State<CounterPage> {
             ),
           if (_frenzy)
             Positioned.fill(
-              child: AnimatedContainer(
-                duration: const Duration(milliseconds: 100),
-                color: _frenzyColor.withOpacity(0.3),
-                child: const SizedBox.expand(),
+              child: IgnorePointer(
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 100),
+                  color: _frenzyColor.withOpacity(0.3),
+                  child: const SizedBox.expand(),
+                ),
               ),
             ),
           if (_ripMode)

--- a/lib/widgets/upgrade_panel.dart
+++ b/lib/widgets/upgrade_panel.dart
@@ -90,36 +90,45 @@ class UpgradePanel extends StatelessWidget {
         final bool affordable10 = currency >= u.cost * 10;
         final bool affordable100 = currency >= u.cost * 100;
         final int maxAffordable = currency ~/ u.cost;
-        return ListTile(
-          title: Text(u.name),
-          subtitle: Text(
-              'Cost: \$${u.cost} - Effect: +${u.effect} per tap - Owned: ${u.owned}'),
-          trailing: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Pulse(
-                active: affordable,
-                child: ElevatedButton(
-                  onPressed: affordable ? () => onPurchase(u, 1) : null,
-                  child: const Text('1'),
+        return Card(
+          margin: const EdgeInsets.symmetric(vertical: 4),
+          child: Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(u.name, style: Theme.of(context).textTheme.subtitle1),
+                Text('Cost: \$${u.cost} - Effect: +${u.effect} per tap - Owned: ${u.owned}'),
+                const SizedBox(height: 8),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    Pulse(
+                      active: affordable,
+                      child: ElevatedButton(
+                        onPressed: affordable ? () => onPurchase(u, 1) : null,
+                        child: const Text('1'),
+                      ),
+                    ),
+                    const SizedBox(width: 4),
+                    ElevatedButton(
+                      onPressed: affordable10 ? () => onPurchase(u, 10) : null,
+                      child: const Text('10'),
+                    ),
+                    const SizedBox(width: 4),
+                    ElevatedButton(
+                      onPressed: affordable100 ? () => onPurchase(u, 100) : null,
+                      child: const Text('100'),
+                    ),
+                    const SizedBox(width: 4),
+                    ElevatedButton(
+                      onPressed: maxAffordable > 0 ? () => onPurchase(u, maxAffordable) : null,
+                      child: const Text('MAX'),
+                    ),
+                  ],
                 ),
-              ),
-              const SizedBox(width: 4),
-              ElevatedButton(
-                onPressed: affordable10 ? () => onPurchase(u, 10) : null,
-                child: const Text('10'),
-              ),
-              const SizedBox(width: 4),
-              ElevatedButton(
-                onPressed: affordable100 ? () => onPurchase(u, 100) : null,
-                child: const Text('100'),
-              ),
-              const SizedBox(width: 4),
-              ElevatedButton(
-                onPressed: maxAffordable > 0 ? () => onPurchase(u, maxAffordable) : null,
-                child: const Text('MAX'),
-              ),
-            ],
+              ],
+            ),
           ),
         );
       }).toList(),


### PR DESCRIPTION
## Summary
- allow taps on the main UI while frenzy mode is active
- restructure upgrade panel to avoid text overlap

## Testing
- `dart format lib/main.dart lib/widgets/upgrade_panel.dart` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68455196f9ac8321890f95c6ef2e0a7c