### PR TITLE
Adjust milestone curve

### DIFF
--- a/lib/models/game_state.dart
+++ b/lib/models/game_state.dart
@@ -20,14 +20,14 @@ class GameState {
   ];
 
   static const List<int> milestoneGoals = [
-    30,
-    150,
-    450,
-    900,
-    1800,
-    3000,
-    6000,
-    15000
+    300,
+    1500,
+    4500,
+    9000,
+    18000,
+    30000,
+    60000,
+    150000
   ];
 
   String get currentMilestone => milestones[milestoneIndex];


### PR DESCRIPTION
## Summary
- stretch milestone progression in `GameState`

## Testing
- `dart format lib/models/game_state.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845523b579483219e558732e599bf67