### PR TITLE
Add tier-specific upgrade and staff maps

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -134,12 +134,7 @@ class _CounterPageState extends State<CounterPage> {
   @override
   void initState() {
     super.initState();
-    upgrades = [
-      Upgrade(name: 'Better Stove', cost: 30, effect: 1),
-      Upgrade(name: 'Sous Chef', cost: 150, effect: 2),
-      Upgrade(name: 'Quantum Oven', cost: 750, effect: 5),
-      Upgrade(name: 'Transdimensional Delivery', cost: 3000, effect: 10),
-    ];
+    upgrades = upgradesForTier(game.milestoneIndex);
     _load();
     _timer = Timer.periodic(const Duration(seconds: 1), (_) => _tickPassive());
     _specialTimer =
@@ -212,6 +207,7 @@ class _CounterPageState extends State<CounterPage> {
       HapticFeedback.heavyImpact();
       final art = milestoneArt[game.milestoneIndex];
       final dialogue = milestoneDialogues[game.milestoneIndex];
+      upgrades = upgradesForTier(game.milestoneIndex);
       showDialog(
         context: context,
         builder: (_) => AlertDialog(
@@ -440,9 +436,10 @@ class _CounterPageState extends State<CounterPage> {
     showModalBottomSheet(
       context: context,
       builder: (_) {
+        final availableStaff = staffByTier[game.milestoneIndex] ?? {};
         return ListView(
-          children: StaffType.values.map((type) {
-            final staff = staffOptions[type]!;
+          children: availableStaff.keys.map((type) {
+            final staff = availableStaff[type]!;
             final owned = hiredStaff[type] ?? 0;
             final affordable = coins >= staff.cost;
             final affordable10 = coins >= staff.cost * 10;
@@ -548,9 +545,7 @@ class _CounterPageState extends State<CounterPage> {
       game.prestige.points = 0;
       coins = 0;
       perTap = 1;
-      for (final u in upgrades) {
-        u.owned = 0;
-      }
+      upgrades = upgradesForTier(game.milestoneIndex);
       for (final p in game.prestige.upgrades) {
         p.purchased = false;
       }

--- a/lib/models/staff.dart
+++ b/lib/models/staff.dart
@@ -1,4 +1,11 @@
-enum StaffType { assistantChef, lineCook, robotChef, timeChef, dimensionManager }
+enum StaffType {
+  tacoFlipper,
+  flyerHandout,
+  waitressOnSkates,
+  grumpyCook,
+  shiftManager,
+  marketingIntern,
+}
 
 class Staff {
   final String name;
@@ -8,12 +15,42 @@ class Staff {
   const Staff({required this.name, required this.cost, required this.tapsPerSecond});
 }
 
+// Individual staff definitions so they can be reused across tier maps.
+const Staff _tacoFlipper =
+    Staff(name: 'Taco Flipper', cost: 50, tapsPerSecond: 0.3);
+const Staff _flyerHandout =
+    Staff(name: 'Flyer Handout Person', cost: 75, tapsPerSecond: 0.1);
+const Staff _waitressOnSkates =
+    Staff(name: 'Waitress on Skates', cost: 400, tapsPerSecond: 1.5);
+const Staff _grumpyCook =
+    Staff(name: 'Grumpy but Efficient Cook', cost: 800, tapsPerSecond: 3.0);
+const Staff _shiftManager =
+    Staff(name: 'Shift Manager', cost: 2000, tapsPerSecond: 5.0);
+const Staff _marketingIntern =
+    Staff(name: 'Marketing Intern', cost: 3500, tapsPerSecond: 1.0);
+
+/// Lookup for all staff by type regardless of tier.
 const Map<StaffType, Staff> staffOptions = {
-  StaffType.assistantChef: Staff(name: 'Assistant Chef', cost: 150, tapsPerSecond: 0.5),
-  StaffType.lineCook: Staff(name: 'Line Cook', cost: 600, tapsPerSecond: 2.0),
-  StaffType.robotChef: Staff(name: 'Robot Chef', cost: 3000, tapsPerSecond: 10.0),
-  StaffType.timeChef:
-      Staff(name: 'Time Traveler Chef', cost: 15000, tapsPerSecond: 50.0),
-  StaffType.dimensionManager:
-      Staff(name: 'Interdimensional Manager', cost: 60000, tapsPerSecond: 200.0),
+  StaffType.tacoFlipper: _tacoFlipper,
+  StaffType.flyerHandout: _flyerHandout,
+  StaffType.waitressOnSkates: _waitressOnSkates,
+  StaffType.grumpyCook: _grumpyCook,
+  StaffType.shiftManager: _shiftManager,
+  StaffType.marketingIntern: _marketingIntern,
+};
+
+/// Staff available for each progression tier.
+const Map<int, Map<StaffType, Staff>> staffByTier = {
+  0: {
+    StaffType.tacoFlipper: _tacoFlipper,
+    StaffType.flyerHandout: _flyerHandout,
+  },
+  1: {
+    StaffType.waitressOnSkates: _waitressOnSkates,
+    StaffType.grumpyCook: _grumpyCook,
+  },
+  2: {
+    StaffType.shiftManager: _shiftManager,
+    StaffType.marketingIntern: _marketingIntern,
+  },
 };

--- a/lib/models/upgrade.dart
+++ b/lib/models/upgrade.dart
@@ -13,3 +13,34 @@ class Upgrade {
     this.owned = 0,
   });
 }
+
+/// Templates of upgrades available for each progression tier.
+///
+/// The lists here should not be mutated directly. When a tier is unlocked,
+/// create fresh [Upgrade] instances based on these templates so that ownership
+/// counts remain local to the player's state.
+final Map<int, List<Upgrade>> upgradesByTier = {
+  0: [
+    Upgrade(name: 'Better Grill', cost: 30, effect: 1),
+    Upgrade(name: 'Heat Lamps', cost: 75, effect: 1),
+    Upgrade(name: 'Bigger Condiment Station', cost: 150, effect: 2),
+  ],
+  1: [
+    Upgrade(name: 'Jukebox', cost: 300, effect: 2),
+    Upgrade(name: 'Milkshake Machine', cost: 600, effect: 3),
+    Upgrade(name: 'Comfier Booths', cost: 1200, effect: 2),
+  ],
+  2: [
+    Upgrade(name: 'Corporate Training', cost: 2500, effect: 3),
+    Upgrade(name: 'Supply Chain Logistics', cost: 5000, effect: 5),
+    Upgrade(name: 'Automated Drive-Thru', cost: 10000, effect: 8),
+  ],
+};
+
+/// Creates a deep copy of the upgrade list for the given [tier].
+List<Upgrade> upgradesForTier(int tier) {
+  final templates = upgradesByTier[tier] ?? const [];
+  return templates
+      .map((u) => Upgrade(name: u.name, cost: u.cost, effect: u.effect))
+      .toList();
+}


### PR DESCRIPTION
## Summary
- create `upgradesByTier` and helper `upgradesForTier`
- restructure staff data into `staffByTier`
- update game logic to pull upgrades and staff for the current milestone
- reset upgrades properly when resetting the game

## Testing
- `git status --short`
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845539892788321bf420f39a980aab2