### PR TITLE
Implement dynamic upgrade and hire panels

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -71,6 +71,28 @@ const List<String> milestoneDialogues = [
   "The multiverse demands endless specials. Hope you're not out of ideas."
 ];
 
+const List<String> upgradePanelTitles = [
+  'Cart Upgrades',
+  'Diner Renovations',
+  'Corporate Overhauls',
+  'Global Improvements',
+  'Galactic Remodels',
+  'Endgame Upgrades',
+  'Temporal Adjustments',
+  'Multiverse Investments',
+];
+
+const List<String> hirePanelTitles = [
+  'Street Crew',
+  'Diner Staff',
+  'Corporate Recruits',
+  'Global Recruiting',
+  'Cosmic Crew',
+  'Endgame Operatives',
+  'Temporal Staff',
+  'Multiverse Talent',
+];
+
 void main() => runApp(const ProviderScope(child: MyApp()));
 
 class MyApp extends StatelessWidget {
@@ -207,7 +229,9 @@ class _CounterPageState extends State<CounterPage> {
       HapticFeedback.heavyImpact();
       final art = milestoneArt[game.milestoneIndex];
       final dialogue = milestoneDialogues[game.milestoneIndex];
-      upgrades = upgradesForTier(game.milestoneIndex);
+      setState(() {
+        upgrades = upgradesForTier(game.milestoneIndex);
+      });
       showDialog(
         context: context,
         builder: (_) => AlertDialog(
@@ -437,8 +461,16 @@ class _CounterPageState extends State<CounterPage> {
       context: context,
       builder: (_) {
         final availableStaff = staffByTier[game.milestoneIndex] ?? {};
+        final title = hirePanelTitles[game.milestoneIndex];
         return ListView(
-          children: availableStaff.keys.map((type) {
+          shrinkWrap: true,
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(16.0),
+              child:
+                  Text(title, style: Theme.of(context).textTheme.titleLarge),
+            ),
+            ...availableStaff.keys.map((type) {
             final staff = availableStaff[type]!;
             final owned = hiredStaff[type] ?? 0;
             final affordable = coins >= staff.cost;
@@ -499,6 +531,7 @@ class _CounterPageState extends State<CounterPage> {
               ),
             );
           }).toList(),
+          ],
         );
       },
     );
@@ -671,6 +704,7 @@ class _CounterPageState extends State<CounterPage> {
               upgrades: upgrades,
               currency: coins,
               onPurchase: _purchase,
+              title: upgradePanelTitles[game.milestoneIndex],
             ),
             const SizedBox(height: 16),
           ElevatedButton(

--- a/lib/widgets/upgrade_panel.dart
+++ b/lib/widgets/upgrade_panel.dart
@@ -74,18 +74,24 @@ class UpgradePanel extends StatelessWidget {
   final List<Upgrade> upgrades;
   final int currency;
   final void Function(Upgrade, int) onPurchase;
+  final String title;
 
   const UpgradePanel({
     super.key,
     required this.upgrades,
     required this.currency,
     required this.onPurchase,
+    required this.title,
   });
 
   @override
   Widget build(BuildContext context) {
     return Column(
-      children: upgrades.map((u) {
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(title, style: Theme.of(context).textTheme.titleLarge),
+        const SizedBox(height: 8),
+        ...upgrades.map((u) {
         final bool affordable = currency >= u.cost;
         final bool affordable10 = currency >= u.cost * 10;
         final bool affordable100 = currency >= u.cost * 100;
@@ -132,6 +138,6 @@ class UpgradePanel extends StatelessWidget {
           ),
         );
       }).toList(),
-    );
+    ]);
   }
 }


### PR DESCRIPTION
## Summary
- add titles to upgrade and hire panels
- refresh upgrade panel when stage changes
- show panel headers based on milestone progression

## Testing
- `bash -lc 'echo no tests'` *(fails: flutter unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6845597f1c688321871f2088913e8d3e