### PR TITLE
Add FrenzyOverlay widget

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'services/storage.dart';
 import 'widgets/upgrade_panel.dart';
 import 'widgets/staff_panel.dart';
 import 'widgets/mini_game_dialog.dart';
+import 'widgets/frenzy_overlay.dart';
 
 const List<String> milestoneArt = [
   r'''
@@ -153,7 +154,6 @@ class _CounterPageState extends State<CounterPage>
   late final AnimationController _frenzyController;
   Timer? _frenzyDurationTimer;
   Offset _frenzyOffset = Offset.zero;
-  Color _frenzyColor = Colors.transparent;
 
   // Special customer state
   Timer? _specialTimer;
@@ -348,7 +348,6 @@ class _CounterPageState extends State<CounterPage>
     setState(() {
       _frenzy = true;
       _combo = _comboMax;
-      _frenzyColor = Colors.red;
     });
     _frenzyController.repeat();
     _frenzyDurationTimer = Timer(const Duration(seconds: 5), () {
@@ -357,7 +356,6 @@ class _CounterPageState extends State<CounterPage>
         _frenzy = false;
         _combo = 0;
         _frenzyOffset = Offset.zero;
-        _frenzyColor = Colors.transparent;
       });
     });
   }
@@ -761,14 +759,8 @@ class _CounterPageState extends State<CounterPage>
               ),
             ),
           if (_frenzy)
-            Positioned.fill(
-              child: IgnorePointer(
-                child: AnimatedContainer(
-                  duration: const Duration(milliseconds: 100),
-                  color: _frenzyColor.withOpacity(0.3),
-                  child: const SizedBox.expand(),
-                ),
-              ),
+            const Positioned.fill(
+              child: FrenzyOverlay(),
             ),
           if (_ripMode)
             Positioned.fill(

--- a/lib/widgets/frenzy_overlay.dart
+++ b/lib/widgets/frenzy_overlay.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+
+/// An overlay used during frenzy mode that animates a vertical gradient
+/// from red/orange at the bottom to transparent at the top.
+class FrenzyOverlay extends StatefulWidget {
+  const FrenzyOverlay({super.key});
+
+  @override
+  State<FrenzyOverlay> createState() => _FrenzyOverlayState();
+}
+
+class _FrenzyOverlayState extends State<FrenzyOverlay>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 400),
+    )..forward();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: AnimatedBuilder(
+        animation: _controller,
+        builder: (context, child) {
+          final height =
+              MediaQuery.of(context).size.height * _controller.value;
+          return Align(
+            alignment: Alignment.bottomCenter,
+            child: Container(
+              height: height,
+              decoration: const BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.bottomCenter,
+                  end: Alignment.topCenter,
+                  colors: [
+                    Colors.red,
+                    Colors.orange,
+                    Colors.transparent,
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add animated FrenzyOverlay widget with a bottom-up gradient
- show FrenzyOverlay instead of AnimatedContainer during frenzy
- clean up unused color field

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e69685188321a82c9bb3c72fb307