### PR TITLE
Add fading milestone overlay

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,7 @@ import 'widgets/upgrade_panel.dart';
 import 'widgets/staff_panel.dart';
 import 'widgets/mini_game_dialog.dart';
 import 'widgets/frenzy_overlay.dart';
+import 'widgets/milestone_overlay.dart';
 
 const List<String> milestoneArt = [
   r'''
@@ -251,18 +252,22 @@ class _CounterPageState extends State<CounterPage>
       setState(() {
         upgrades = upgradesForTier(game.milestoneIndex);
       });
-      showDialog(
+      showGeneralDialog(
         context: context,
-        builder: (_) => AlertDialog(
-          title: Text('Milestone: ${game.currentMilestone}'),
-          content: SingleChildScrollView(child: Text(art)),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: const Text('Nice!'),
+        barrierDismissible: false,
+        barrierLabel: 'milestone',
+        barrierColor: Colors.white,
+        transitionDuration: const Duration(milliseconds: 400),
+        pageBuilder: (context, animation, secondaryAnimation) {
+          return FadeTransition(
+            opacity: animation,
+            child: MilestoneOverlay(
+              title: 'Milestone: ${game.currentMilestone}',
+              art: art,
+              onContinue: () => Navigator.pop(context),
             ),
-          ],
-        ),
+          );
+        },
       );
       ScaffoldMessenger.of(context)
           .showSnackBar(SnackBar(content: Text(dialogue)));

--- a/lib/widgets/milestone_overlay.dart
+++ b/lib/widgets/milestone_overlay.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+class MilestoneOverlay extends StatelessWidget {
+  final String title;
+  final String art;
+  final VoidCallback onContinue;
+
+  const MilestoneOverlay({
+    super.key,
+    required this.title,
+    required this.art,
+    required this.onContinue,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onContinue,
+      child: Container(
+        color: Colors.white,
+        alignment: Alignment.center,
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              title,
+              style: Theme.of(context).textTheme.headlineSmall,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              art,
+              textAlign: TextAlign.center,
+              style: const TextStyle(fontFamily: 'monospace'),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: onContinue,
+              child: const Text('Open new restaurant milestone'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show milestone screen as fading overlay
- add MilestoneOverlay widget

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ef61c5c48321bd6f7462177e1110