### PR TITLE
Add GameController and refactor gameplay

### DIFF
--- a/lib/controllers/game_controller.dart
+++ b/lib/controllers/game_controller.dart
@@ -1,0 +1,271 @@
+import 'dart:async';
+import 'dart:math';
+import 'package:flutter/material.dart';
+import '../models/game_state.dart';
+import '../models/staff.dart';
+import '../models/upgrade.dart';
+import '../services/storage.dart';
+
+class GameController extends ChangeNotifier {
+  final GameState game;
+  final StorageService _storage;
+
+  GameController({GameState? state, StorageService? storage})
+      : game = state ?? GameState(),
+        _storage = storage ?? StorageService() {
+    upgrades = upgradesForTier(game.milestoneIndex);
+  }
+
+  late final Timer _timer;
+  Timer? _specialTimer;
+
+  int coins = 0;
+  int perTap = 1;
+  late List<Upgrade> upgrades;
+
+  final Map<StaffType, int> hiredStaff = {};
+  double _passiveProgress = 0;
+  int _lastMilestoneIndex = 0;
+  int get lastMilestoneIndex => _lastMilestoneIndex;
+  double currentTPS = 0;
+
+  bool ripMode = false;
+  Color ripColor = Colors.transparent;
+  double ripRotation = 0;
+  Timer? ripTimer;
+
+  bool adBoostActive = false;
+  int adBoostSeconds = 0;
+  Timer? adBoostTimer;
+
+  int combo = 0;
+  Timer? comboTimer;
+  Timer? frenzyWarmupTimer;
+  Timer? frenzyDurationTimer;
+  static const int comboMax = 20;
+  static const Duration comboTimeout = Duration(seconds: 3);
+
+  bool frenzy = false;
+
+  bool specialVisible = false;
+
+  Future<OfflineLoadResult> load() async {
+    final result = await _storage.loadGame(idleMultiplier: 0.000833);
+    game.mealsServed = result.count;
+    coins += result.earned;
+    _lastMilestoneIndex = game.milestoneIndex;
+    notifyListeners();
+    return result;
+  }
+
+  void start() {
+    _timer = Timer.periodic(const Duration(seconds: 1), (_) => _tickPassive());
+    _specialTimer =
+        Timer.periodic(const Duration(seconds: 20), (_) => _spawnSpecial());
+  }
+
+  Future<void> save() async => _storage.saveGame(game.mealsServed);
+
+  void cook() {
+    _incrementCombo();
+    for (int i = 0; i < perTap; i++) {
+      game.cook();
+    }
+    coins += perTap * currentMultiplier;
+    _checkMilestone();
+    notifyListeners();
+    save();
+  }
+
+  void addCoins(int amount) {
+    coins += amount;
+    notifyListeners();
+  }
+
+  void purchase(Upgrade upgrade, int quantity) {
+    if (quantity <= 0) return;
+    final int totalCost = upgrade.cost * quantity;
+    if (coins >= totalCost) {
+      coins -= totalCost;
+      perTap += upgrade.effect * quantity;
+      upgrade.owned += quantity;
+      notifyListeners();
+    }
+  }
+
+  void _tickPassive() {
+    double tapsPerSecond = 0;
+    hiredStaff.forEach((type, qty) {
+      final staff = staffOptions[type]!;
+      tapsPerSecond += staff.tapsPerSecond * qty;
+    });
+    _passiveProgress += tapsPerSecond;
+    final int whole = _passiveProgress.floor();
+    _passiveProgress -= whole;
+    currentTPS = tapsPerSecond;
+    if (whole > 0) {
+      for (int i = 0; i < whole; i++) {
+        game.cook();
+      }
+      coins += perTap * whole;
+    }
+    _checkMilestone();
+    notifyListeners();
+  }
+
+  void _checkMilestone() {
+    if (_lastMilestoneIndex != game.milestoneIndex) {
+      _lastMilestoneIndex = game.milestoneIndex;
+      upgrades = upgradesForTier(game.milestoneIndex);
+      notifyListeners();
+    }
+  }
+
+  void hireStaff(StaffType type, int quantity) {
+    final staff = staffOptions[type]!;
+    final int totalCost = staff.cost * quantity;
+    if (coins >= totalCost) {
+      coins -= totalCost;
+      hiredStaff[type] = (hiredStaff[type] ?? 0) + quantity;
+      notifyListeners();
+    }
+  }
+
+  void _spawnSpecial() {
+    if (specialVisible) return;
+    if (Random().nextDouble() < 0.5) {
+      specialVisible = true;
+      Timer(const Duration(seconds: 10), () {
+        specialVisible = false;
+        notifyListeners();
+      });
+      notifyListeners();
+    }
+  }
+
+  void hideSpecial() {
+    specialVisible = false;
+    notifyListeners();
+  }
+
+  Future<void> rewardSpecial(int taps) async {
+    coins += taps * 10;
+    notifyListeners();
+  }
+
+  int get currentMultiplier {
+    final base = frenzy ? 5 : 1 + (combo ~/ 2);
+    return adBoostActive ? base * 2 : base;
+  }
+
+  void _incrementCombo() {
+    comboTimer?.cancel();
+    _updateComboAndFrenzy();
+    comboTimer = Timer(comboTimeout, () {
+      frenzyWarmupTimer?.cancel();
+      combo = (combo - 2).clamp(0, comboMax);
+      notifyListeners();
+    });
+  }
+
+  void _updateComboAndFrenzy() {
+    if (combo < comboMax) {
+      combo += 1;
+    }
+    if (combo >= comboMax && !frenzy) {
+      _startFrenzyWarmup();
+    }
+  }
+
+  void _startFrenzyWarmup() {
+    if (frenzy) return;
+    frenzyWarmupTimer?.cancel();
+    frenzyWarmupTimer = Timer(const Duration(seconds: 1), () {
+      if (combo >= comboMax && !frenzy) {
+        _startFrenzyMode();
+      }
+    });
+  }
+
+  void _startFrenzyMode() {
+    if (frenzy) return;
+    frenzyWarmupTimer?.cancel();
+    frenzyDurationTimer?.cancel();
+    frenzy = true;
+    combo = comboMax;
+    notifyListeners();
+    frenzyDurationTimer = Timer(const Duration(seconds: 5), () {
+      frenzy = false;
+      combo = 0;
+      notifyListeners();
+    });
+  }
+
+  void startRipMode() {
+    if (ripMode) return;
+    ripMode = true;
+    ripColor = Colors.green;
+    ripRotation = (Random().nextDouble() - 0.5) * 0.2;
+    ripTimer = Timer.periodic(const Duration(milliseconds: 300), (_) {
+      ripRotation = (Random().nextDouble() - 0.5) * 0.2;
+      notifyListeners();
+    });
+    Timer(const Duration(seconds: 10), () {
+      ripTimer?.cancel();
+      ripTimer = null;
+      ripMode = false;
+      notifyListeners();
+    });
+  }
+
+  void startAdBoost() {
+    adBoostTimer?.cancel();
+    adBoostActive = true;
+    adBoostSeconds = 300;
+    notifyListeners();
+    adBoostTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      if (adBoostSeconds <= 1) {
+        timer.cancel();
+        adBoostActive = false;
+        adBoostSeconds = 0;
+        notifyListeners();
+      } else {
+        adBoostSeconds--;
+        notifyListeners();
+      }
+    });
+  }
+
+  Future<bool> watchAd() async {
+    await Future.delayed(const Duration(seconds: 2));
+    return true;
+  }
+
+  Future<void> resetGame() async {
+    await _storage.clear();
+    game.resetProgress();
+    game.prestige.points = 0;
+    coins = 0;
+    perTap = 1;
+    upgrades = upgradesForTier(game.milestoneIndex);
+    for (final p in game.prestige.upgrades) {
+      p.purchased = false;
+    }
+    hiredStaff.clear();
+    _passiveProgress = 0;
+    _lastMilestoneIndex = 0;
+    currentTPS = 0;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _timer.cancel();
+    ripTimer?.cancel();
+    frenzyDurationTimer?.cancel();
+    _specialTimer?.cancel();
+    adBoostTimer?.cancel();
+    save();
+    super.dispose();
+  }
+}

--- a/lib/providers/game_controller_provider.dart
+++ b/lib/providers/game_controller_provider.dart
@@ -1,0 +1,5 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../controllers/game_controller.dart';
+
+final gameControllerProvider =
+    ChangeNotifierProvider<GameController>((ref) => GameController());

--- a/lib/widgets/ad_reward_sheet.dart
+++ b/lib/widgets/ad_reward_sheet.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+class AdRewardSheet extends StatelessWidget {
+  final VoidCallback onFiveMin;
+  final VoidCallback onCoins;
+
+  const AdRewardSheet({
+    super.key,
+    required this.onFiveMin,
+    required this.onCoins,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        ListTile(
+          leading: const Icon(Icons.timer),
+          title: const Text('Double earnings for 5 minutes'),
+          onTap: onFiveMin,
+        ),
+        ListTile(
+          leading: const Icon(Icons.attach_money),
+          title: const Text('Get 100 coins'),
+          onTap: onCoins,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/offline_earnings_dialog.dart
+++ b/lib/widgets/offline_earnings_dialog.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+class OfflineEarningsDialog extends StatelessWidget {
+  final int earned;
+  final VoidCallback onClose;
+  final VoidCallback onDouble;
+
+  const OfflineEarningsDialog({
+    super.key,
+    required this.earned,
+    required this.onClose,
+    required this.onDouble,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Welcome Back!'),
+      content: Text('You earned $earned coins while you were away.'),
+      actions: [
+        TextButton(onPressed: onClose, child: const Text('Nice')),
+        TextButton(onPressed: onDouble, child: const Text('Double for Ad')),
+      ],
+    );
+  }
+}

--- a/lib/widgets/prestige_sheet.dart
+++ b/lib/widgets/prestige_sheet.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import '../models/prestige.dart';
+
+class PrestigeSheet extends StatelessWidget {
+  final List<PrestigeUpgrade> upgrades;
+  final void Function(String id) onPurchase;
+  final int points;
+
+  const PrestigeSheet({
+    super.key,
+    required this.upgrades,
+    required this.onPurchase,
+    required this.points,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      children: upgrades.map((upgrade) {
+        final canBuy = points >= upgrade.cost && !upgrade.purchased;
+        return ListTile(
+          title: Text(upgrade.name),
+          subtitle: Text('${upgrade.description} - Cost: ${upgrade.cost} PP'),
+          trailing: upgrade.purchased
+              ? const Icon(Icons.check, color: Colors.green)
+              : ElevatedButton(
+                  onPressed: canBuy ? () => onPurchase(upgrade.id) : null,
+                  child: const Text('Buy'),
+                ),
+        );
+      }).toList(),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- move gameplay logic into `GameController`
- provide `gameControllerProvider` for Riverpod
- break out UI widgets for dialogs and bottom sheets
- simplify `CounterPage` to use `GameController`

## Testing
- `dart format` *(fails: `dart` not found)*
- `flutter --version` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68460e706d04832194ff29f36cf29cd0