### PR TITLE
Refactor constants into dedicated files

### DIFF
--- a/lib/constants/milestones.dart
+++ b/lib/constants/milestones.dart
@@ -1,0 +1,58 @@
+const List<String> milestoneArt = [
+  r'''
+  ( )
+ /|_|\\
+ /___\\
+  ''',
+  r'''
+  |~~~~|
+  |DNR |
+  |____|
+  ''',
+  r'''
+   _____
+  |[ ] |
+  |[ ] |
+  |____|
+  ''',
+  r'''
+  .----.
+ / .--. \\
+| |    | |
+ \\ '--' /
+  `----'
+  ''',
+  r'''
+  .-.
+ (o o)
+  |=|
+ __|__
+/_____\\
+  ''',
+  r'''
+  (X_X)
+   /|\\
+  /_|_\\
+  ''',
+  r'''
+  <\\/>
+  (oo)
+  /||\\
+  ''',
+  r'''
+   *-|-*
+  /o\\
+  \\v/
+  ''',
+];
+
+const List<String> milestoneDialogues = [
+  "Street cart fans now chant your menu. This is totally normal.",
+  "Your diner draws crowds - and a new existential crisis.",
+  "Congrats, you're corporate! Please ignore the accountants in the kitchen.",
+  "Entire nations line up. Is this still about food?",
+  "Starships detour just to taste your fries. Space smells like success.",
+  "You've fed the galaxy. Nothing left but existential hunger.",
+  "Time loops around the kitchen. Omelettes now cause deja vu.",
+  "The multiverse demands endless specials. Hope you're not out of ideas.",
+];

--- a/lib/constants/panels.dart
+++ b/lib/constants/panels.dart
@@ -1,0 +1,21 @@
+const List<String> upgradePanelTitles = [
+  'Cart Upgrades',
+  'Diner Renovations',
+  'Corporate Overhauls',
+  'Global Improvements',
+  'Galactic Remodels',
+  'Endgame Upgrades',
+  'Temporal Adjustments',
+  'Multiverse Investments',
+];
+
+const List<String> hirePanelTitles = [
+  'Street Crew',
+  'Diner Staff',
+  'Corporate Recruits',
+  'Global Recruiting',
+  'Cosmic Crew',
+  'Endgame Operatives',
+  'Temporal Staff',
+  'Multiverse Talent',
+];

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,87 +19,8 @@ import 'widgets/staff_panel.dart';
 import 'widgets/mini_game_dialog.dart';
 import 'widgets/frenzy_overlay.dart';
 import 'widgets/milestone_overlay.dart';
-
-const List<String> milestoneArt = [
-  r'''
-  ( )
- /|_|\\
- /___\\
-  ''',
-  r'''
-  |~~~~|
-  |DNR |
-  |____|
-  ''',
-  r'''
-   _____
-  |[ ] |
-  |[ ] |
-  |____|
-  ''',
-  r'''
-  .----.
- / .--. \\
-| |    | |
- \\ '--' /
-  `----'
-  ''',
-  r'''
-  .-.
- (o o)
-  |=|
- __|__
-/_____\\
-  ''',
-  r'''
-  (X_X)
-   /|\\
-  /_|_\\
-  ''',
-  r'''
-  <\\/>
-  (oo)
-  /||\\
-  ''',
-  r'''
-   *-|-*
-  /o\\
-  \\v/
-  ''',
-];
-
-const List<String> milestoneDialogues = [
-  "Street cart fans now chant your menu. This is totally normal.",
-  "Your diner draws crowds - and a new existential crisis.",
-  "Congrats, you're corporate! Please ignore the accountants in the kitchen.",
-  "Entire nations line up. Is this still about food?",
-  "Starships detour just to taste your fries. Space smells like success.",
-  "You've fed the galaxy. Nothing left but existential hunger.",
-  "Time loops around the kitchen. Omelettes now cause deja vu.",
-  "The multiverse demands endless specials. Hope you're not out of ideas."
-];
-
-const List<String> upgradePanelTitles = [
-  'Cart Upgrades',
-  'Diner Renovations',
-  'Corporate Overhauls',
-  'Global Improvements',
-  'Galactic Remodels',
-  'Endgame Upgrades',
-  'Temporal Adjustments',
-  'Multiverse Investments',
-];
-
-const List<String> hirePanelTitles = [
-  'Street Crew',
-  'Diner Staff',
-  'Corporate Recruits',
-  'Global Recruiting',
-  'Cosmic Crew',
-  'Endgame Operatives',
-  'Temporal Staff',
-  'Multiverse Talent',
-];
+import 'constants/milestones.dart';
+import 'constants/panels.dart';
 
 void main() => runApp(const ProviderScope(child: MyApp()));
 


### PR DESCRIPTION
## Summary
- add new `lib/constants/` directory
- move milestone art/dialogues into `constants/milestones.dart`
- move panel titles into `constants/panels.dart`
- update imports in `main.dart`

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684615ad429c8321ac5bdb2c239749eb