### PR TITLE
Add initial unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Flutter Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+      - run: flutter test

--- a/README.md
+++ b/README.md
@@ -114,3 +114,13 @@ This repository now includes a minimal Flutter application. To run it locally:
    ```
 
 The starter app tracks how many meals you've cooked each time you tap the **Cook!** button.
+
+## 🧪 Running Tests
+
+To run the automated unit tests, ensure the Flutter SDK is installed and execute:
+
+```bash
+flutter test
+```
+
+This command builds the test environment and runs all suites under `test/`.

--- a/test/game_state_test.dart
+++ b/test/game_state_test.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:taptapchef/models/game_state.dart';
+
+void main() {
+  test('milestone progresses when goal reached', () {
+    final game = GameState();
+    for (var i = 0; i < GameState.milestoneGoals[0]; i++) {
+      game.cook();
+    }
+    expect(game.milestoneIndex, 1);
+    expect(game.mealsServed, 0);
+  });
+}

--- a/test/prestige_test.dart
+++ b/test/prestige_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:taptapchef/models/prestige.dart';
+
+void main() {
+  test('purchase succeeds with enough points', () {
+    final prestige = Prestige(points: 5);
+    final success = prestige.purchase('income_2_percent');
+    expect(success, isTrue);
+    expect(prestige.points, 2); // cost is 3
+    expect(prestige.hasUpgrade('income_2_percent'), isTrue);
+  });
+
+  test('purchase fails when insufficient points', () {
+    final prestige = Prestige(points: 0);
+    final success = prestige.purchase('income_2_percent');
+    expect(success, isFalse);
+    expect(prestige.points, 0);
+    expect(prestige.hasUpgrade('income_2_percent'), isFalse);
+  });
+}

--- a/test/storage_service_test.dart
+++ b/test/storage_service_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:taptapchef/services/storage.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('loadGame applies idle earnings', () async {
+    final now = DateTime.now();
+    SharedPreferences.setMockInitialValues({
+      'count': 100,
+      'timestamp': now.subtract(const Duration(seconds: 10)).millisecondsSinceEpoch,
+    });
+
+    final service = StorageService();
+    final result = await service.loadGame(idleMultiplier: 1.0);
+
+    expect(result.earned, 10);
+    expect(result.count, 110);
+
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getInt('count'), 110);
+  });
+
+  test('loadGame with no saved data returns zeros', () async {
+    SharedPreferences.setMockInitialValues({});
+
+    final service = StorageService();
+    final result = await service.loadGame(idleMultiplier: 1.0);
+
+    expect(result.earned, 0);
+    expect(result.count, 0);
+  });
+}


### PR DESCRIPTION
## Summary
- add simple workflow to run flutter tests
- document `flutter test` command
- unit tests for `GameState`, `Prestige.purchase`, and `StorageService.loadGame`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461abb160483219e286cc049de62e5