### PR TITLE
Fix import for GameState

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,6 +21,7 @@ import 'widgets/frenzy_overlay.dart';
 import 'widgets/milestone_overlay.dart';
 import 'constants/milestones.dart';
 import 'constants/panels.dart';
+import 'models/game_state.dart';
 
 void main() => runApp(const ProviderScope(child: MyApp()));
 


### PR DESCRIPTION
## Summary
- import `GameState` in `main.dart`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461dba6a088321ad118b6f1235c9e4