### PR TITLE
Restore rip mode overlay

### DIFF
--- a/lib/controllers/game_controller.dart
+++ b/lib/controllers/game_controller.dart
@@ -210,7 +210,7 @@ class GameController extends ChangeNotifier {
       ripRotation = (Random().nextDouble() - 0.5) * 0.2;
       notifyListeners();
     });
-    Timer(const Duration(seconds: 10), () {
+    Timer(const Duration(seconds: 8), () {
       ripTimer?.cancel();
       ripTimer = null;
       ripMode = false;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -255,6 +255,11 @@ class _CounterPageState extends ConsumerState<CounterPage>
     }
   }
 
+  void _startRipMode() {
+    HapticFeedback.lightImpact();
+    controller.startRipMode();
+  }
+
   @override
   void dispose() {
     controller.removeListener(_controllerListener);
@@ -387,7 +392,7 @@ class _CounterPageState extends ConsumerState<CounterPage>
                 Positioned.fill(
                   child: AnimatedContainer(
                     duration: const Duration(milliseconds: 300),
-                    color: controller.ripColor.withOpacity(0.5),
+                    color: controller.ripColor.withOpacity(0.3),
                     child: Transform.rotate(
                       angle: controller.ripRotation,
                       child: const SizedBox.expand(),


### PR DESCRIPTION
## Summary
- reintroduce rip mode controls in the UI
- reduce rip mode duration from 10s to 8s
- lighten the overlay color for a subtle trippy effect

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461ec3a2248321997821b49a40109d