### PR TITLE
Implement Franchise Deals prestige system

### DIFF
--- a/lib/controllers/game_controller.dart
+++ b/lib/controllers/game_controller.dart
@@ -54,6 +54,7 @@ class GameController extends ChangeNotifier {
     game.mealsServed = result.count;
     coins += result.earned;
     _lastMilestoneIndex = game.milestoneIndex;
+    await _storage.loadFranchiseData(game);
     notifyListeners();
     return result;
   }
@@ -64,7 +65,10 @@ class GameController extends ChangeNotifier {
         Timer.periodic(const Duration(seconds: 20), (_) => _spawnSpecial());
   }
 
-  Future<void> save() async => _storage.saveGame(game.mealsServed);
+  Future<void> save() async {
+    await _storage.saveGame(game.mealsServed);
+    await _storage.saveFranchiseData(game);
+  }
 
   void cook() {
     _incrementCombo();
@@ -245,6 +249,9 @@ class GameController extends ChangeNotifier {
     await _storage.clear();
     game.resetProgress();
     game.prestige.points = 0;
+    game.franchiseTokens = 0;
+    game.currentLocationIndex = 0;
+    game.purchasedPrestigeUpgrades.clear();
     coins = 0;
     perTap = 1;
     upgrades = upgradesForTier(game.milestoneIndex);

--- a/lib/models/franchise_location.dart
+++ b/lib/models/franchise_location.dart
@@ -1,0 +1,24 @@
+class FranchiseLocation {
+  final String name;
+  final String tierName;
+  final String artAsset;
+
+  const FranchiseLocation({
+    required this.name,
+    required this.tierName,
+    required this.artAsset,
+  });
+}
+
+const List<FranchiseLocation> franchiseProgression = [
+  FranchiseLocation(name: 'Nashville', tierName: 'City', artAsset: 'assets/images/nashville.png'),
+  FranchiseLocation(name: 'New York', tierName: 'City', artAsset: 'assets/images/new_york.png'),
+  FranchiseLocation(name: 'Tokyo', tierName: 'City', artAsset: 'assets/images/tokyo.png'),
+
+  FranchiseLocation(name: 'USA', tierName: 'Country', artAsset: 'assets/images/usa.png'),
+  FranchiseLocation(name: 'Canada', tierName: 'Country', artAsset: 'assets/images/canada.png'),
+  FranchiseLocation(name: 'Japan', tierName: 'Country', artAsset: 'assets/images/japan.png'),
+
+  FranchiseLocation(name: 'Earth', tierName: 'Planet', artAsset: 'assets/images/earth.png'),
+  FranchiseLocation(name: 'Mars', tierName: 'Planet', artAsset: 'assets/images/mars.png'),
+];

--- a/lib/models/game_state.dart
+++ b/lib/models/game_state.dart
@@ -1,11 +1,19 @@
 import 'package:flutter/foundation.dart';
 
 import 'prestige.dart';
+import 'franchise_location.dart';
+import 'prestige_upgrade.dart';
 
 class GameState extends ChangeNotifier {
   int mealsServed;
   int milestoneIndex;
   final Prestige prestige;
+  int franchiseTokens = 0;
+  int currentLocationIndex = 0;
+  Map<String, int> purchasedPrestigeUpgrades = {};
+
+  FranchiseLocation get currentLocation =>
+      franchiseProgression[currentLocationIndex];
 
   GameState({this.mealsServed = 0, this.milestoneIndex = 0, Prestige? prestige})
       : prestige = prestige ?? Prestige();
@@ -53,8 +61,22 @@ class GameState extends ChangeNotifier {
 
   void prestigeUp() {
     if (atFinalMilestone) {
-      prestige.gainPoint();
+      int tokensEarned = 1 + (mealsServed ~/ 1000);
+      franchiseTokens += tokensEarned;
+      currentLocationIndex =
+          (currentLocationIndex + 1) % franchiseProgression.length;
       resetProgress();
     }
+  }
+
+  void purchasePrestigeUpgrade(String upgradeId) {
+    final upgrade = prestigeUpgrades[upgradeId];
+    if (upgrade == null) return;
+    final currentLevel = purchasedPrestigeUpgrades[upgradeId] ?? 0;
+    final cost = upgrade.getCost(currentLevel);
+    if (cost == -1 || franchiseTokens < cost) return;
+    franchiseTokens -= cost;
+    purchasedPrestigeUpgrades[upgradeId] = currentLevel + 1;
+    notifyListeners();
   }
 }

--- a/lib/models/prestige_upgrade.dart
+++ b/lib/models/prestige_upgrade.dart
@@ -1,0 +1,48 @@
+class PrestigeUpgrade {
+  final String id;
+  final String name;
+  final String description;
+  final int maxLevel;
+  final int baseCost;
+  final double costMultiplier;
+
+  PrestigeUpgrade({
+    required this.id,
+    required this.name,
+    required this.description,
+    this.maxLevel = 10,
+    this.baseCost = 1,
+    this.costMultiplier = 1.5,
+  });
+
+  int getCost(int currentLevel) {
+    if (currentLevel >= maxLevel) return -1;
+    return (baseCost * (costMultiplier * currentLevel)).ceil() + baseCost;
+  }
+}
+
+final Map<String, PrestigeUpgrade> prestigeUpgrades = {
+  'michelin_star': PrestigeUpgrade(
+    id: 'michelin_star',
+    name: 'Michelin Star Training',
+    description: '+10% to all profits per level.',
+    maxLevel: 20,
+    baseCost: 1,
+    costMultiplier: 1.2,
+  ),
+  'celeb_endorsement': PrestigeUpgrade(
+    id: 'celeb_endorsement',
+    name: 'Celebrity Chef Endorsement',
+    description: 'Start every new Franchise with the first 2 staff members already hired.',
+    maxLevel: 1,
+    baseCost: 10,
+  ),
+  'ghost_kitchens': PrestigeUpgrade(
+    id: 'ghost_kitchens',
+    name: 'Ghost Kitchens',
+    description: 'Retain 5% of your previous Franchise\'s passive income per level.',
+    maxLevel: 5,
+    baseCost: 5,
+    costMultiplier: 2.0,
+  ),
+};

--- a/lib/widgets/franchise_hq.dart
+++ b/lib/widgets/franchise_hq.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import '../models/game_state.dart';
+import '../models/franchise_location.dart';
+import '../models/prestige_upgrade.dart';
+
+class FranchiseHQ extends StatelessWidget {
+  final GameState game;
+  final void Function(String id) onPurchase;
+
+  const FranchiseHQ({
+    super.key,
+    required this.game,
+    required this.onPurchase,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final upgrades = prestigeUpgrades.values.toList();
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Location Progression', style: Theme.of(context).textTheme.titleLarge),
+          const SizedBox(height: 8),
+          ...franchiseProgression.map((loc) {
+            final index = franchiseProgression.indexOf(loc);
+            String status;
+            if (index < game.currentLocationIndex) {
+              status = 'Completed';
+            } else if (index == game.currentLocationIndex) {
+              status = 'Current';
+            } else {
+              status = 'Upcoming';
+            }
+            return ListTile(
+              leading: Image.asset(loc.artAsset, width: 40, height: 40, errorBuilder: (_, __, ___) => const SizedBox(width: 40, height: 40)),
+              title: Text(loc.name),
+              subtitle: Text('${loc.tierName} - $status'),
+            );
+          }),
+          const Divider(),
+          Text('Prestige Upgrades', style: Theme.of(context).textTheme.titleLarge),
+          const SizedBox(height: 8),
+          ...upgrades.map((u) {
+            final level = game.purchasedPrestigeUpgrades[u.id] ?? 0;
+            final cost = u.getCost(level);
+            final maxed = cost == -1;
+            final canBuy = !maxed && game.franchiseTokens >= cost;
+            return ListTile(
+              title: Text(u.name),
+              subtitle: Text('${u.description}\nLevel: $level/${u.maxLevel} - Cost: ${maxed ? 'MAX' : cost}'),
+              trailing: maxed
+                  ? const Icon(Icons.check, color: Colors.green)
+                  : ElevatedButton(
+                      onPressed: canBuy ? () => onPurchase(u.id) : null,
+                      child: const Text('Buy'),
+                    ),
+            );
+          })
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add franchise location data model with progression list
- add prestige upgrade definitions
- extend `GameState` with franchise tokens, location, and upgrade purchasing
- persist new data in `StorageService`
- update `GameController` to load/save new data
- create `FranchiseHQ` screen for location progress and upgrades
- update main UI to show location, tokens, and new franchise deal flow

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846655a5d348321809ece36561aa3bb