### PR TITLE
Expand late-game content

### DIFF
--- a/lib/models/game_state.dart
+++ b/lib/models/game_state.dart
@@ -30,14 +30,14 @@ class GameState extends ChangeNotifier {
   ];
 
   static const List<int> milestoneGoals = [
-    600,
-    3000,
-    9000,
-    18000,
-    36000,
-    60000,
-    120000,
-    300000
+    4800,
+    24000,
+    72000,
+    144000,
+    288000,
+    480000,
+    960000,
+    2400000
   ];
 
   String get currentMilestone => milestones[milestoneIndex];

--- a/lib/models/staff.dart
+++ b/lib/models/staff.dart
@@ -5,6 +5,16 @@ enum StaffType {
   grumpyCook,
   shiftManager,
   marketingIntern,
+  corporateConsultant,
+  brandAmbassador,
+  alienSousChef,
+  robotServer,
+  aiHost,
+  quantumCook,
+  chronoChef,
+  timeWaiter,
+  multiverseManager,
+  realityServer,
 }
 
 class Staff {
@@ -29,6 +39,26 @@ const Staff _shiftManager =
     Staff(name: 'Shift Manager', cost: 2000, tapsPerSecond: 5.0);
 const Staff _marketingIntern =
     Staff(name: 'Marketing Intern', cost: 3500, tapsPerSecond: 1.0);
+const Staff _corporateConsultant =
+    Staff(name: 'Corporate Consultant', cost: 5000, tapsPerSecond: 6.0);
+const Staff _brandAmbassador =
+    Staff(name: 'Brand Ambassador', cost: 7500, tapsPerSecond: 8.0);
+const Staff _alienSousChef =
+    Staff(name: 'Alien Sous Chef', cost: 15000, tapsPerSecond: 12.0);
+const Staff _robotServer =
+    Staff(name: 'Robot Server', cost: 25000, tapsPerSecond: 15.0);
+const Staff _aiHost =
+    Staff(name: 'AI Host', cost: 40000, tapsPerSecond: 20.0);
+const Staff _quantumCook =
+    Staff(name: 'Quantum Cook', cost: 60000, tapsPerSecond: 25.0);
+const Staff _chronoChef =
+    Staff(name: 'Chrono Chef', cost: 100000, tapsPerSecond: 30.0);
+const Staff _timeWaiter =
+    Staff(name: 'Time Waiter', cost: 150000, tapsPerSecond: 35.0);
+const Staff _multiverseManager =
+    Staff(name: 'Multiverse Manager', cost: 250000, tapsPerSecond: 45.0);
+const Staff _realityServer =
+    Staff(name: 'Reality Server', cost: 400000, tapsPerSecond: 60.0);
 
 /// Lookup for all staff by type regardless of tier.
 const Map<StaffType, Staff> staffOptions = {
@@ -38,6 +68,16 @@ const Map<StaffType, Staff> staffOptions = {
   StaffType.grumpyCook: _grumpyCook,
   StaffType.shiftManager: _shiftManager,
   StaffType.marketingIntern: _marketingIntern,
+  StaffType.corporateConsultant: _corporateConsultant,
+  StaffType.brandAmbassador: _brandAmbassador,
+  StaffType.alienSousChef: _alienSousChef,
+  StaffType.robotServer: _robotServer,
+  StaffType.aiHost: _aiHost,
+  StaffType.quantumCook: _quantumCook,
+  StaffType.chronoChef: _chronoChef,
+  StaffType.timeWaiter: _timeWaiter,
+  StaffType.multiverseManager: _multiverseManager,
+  StaffType.realityServer: _realityServer,
 };
 
 /// Staff available for each progression tier.
@@ -53,5 +93,25 @@ const Map<int, Map<StaffType, Staff>> staffByTier = {
   2: {
     StaffType.shiftManager: _shiftManager,
     StaffType.marketingIntern: _marketingIntern,
+  },
+  3: {
+    StaffType.corporateConsultant: _corporateConsultant,
+    StaffType.brandAmbassador: _brandAmbassador,
+  },
+  4: {
+    StaffType.alienSousChef: _alienSousChef,
+    StaffType.robotServer: _robotServer,
+  },
+  5: {
+    StaffType.aiHost: _aiHost,
+    StaffType.quantumCook: _quantumCook,
+  },
+  6: {
+    StaffType.chronoChef: _chronoChef,
+    StaffType.timeWaiter: _timeWaiter,
+  },
+  7: {
+    StaffType.multiverseManager: _multiverseManager,
+    StaffType.realityServer: _realityServer,
   },
 };

--- a/lib/models/upgrade.dart
+++ b/lib/models/upgrade.dart
@@ -35,6 +35,31 @@ final Map<int, List<Upgrade>> upgradesByTier = {
     Upgrade(name: 'Supply Chain Logistics', cost: 5000, effect: 5),
     Upgrade(name: 'Automated Drive-Thru', cost: 10000, effect: 8),
   ],
+  3: [
+    Upgrade(name: 'Global Advertising', cost: 20000, effect: 10),
+    Upgrade(name: 'Celebrity Chef Partnership', cost: 40000, effect: 12),
+    Upgrade(name: 'International Logistics', cost: 80000, effect: 15),
+  ],
+  4: [
+    Upgrade(name: 'Zero-G Kitchens', cost: 150000, effect: 20),
+    Upgrade(name: 'Alien Ingredient Contracts', cost: 300000, effect: 30),
+    Upgrade(name: 'Hyperdrive Delivery', cost: 600000, effect: 45),
+  ],
+  5: [
+    Upgrade(name: 'Singularity Stove', cost: 1000000, effect: 60),
+    Upgrade(name: 'Quantum Spice Rack', cost: 1500000, effect: 80),
+    Upgrade(name: 'AI Gourmet Designer', cost: 2000000, effect: 100),
+  ],
+  6: [
+    Upgrade(name: 'Time Dilation Oven', cost: 2500000, effect: 120),
+    Upgrade(name: 'Chrono Shift Staff', cost: 3500000, effect: 160),
+    Upgrade(name: 'Paradox Inventory', cost: 5000000, effect: 200),
+  ],
+  7: [
+    Upgrade(name: 'Dimensional Dining Room', cost: 8000000, effect: 250),
+    Upgrade(name: 'Infinite Menu Generator', cost: 10000000, effect: 300),
+    Upgrade(name: 'Reality Distortion Service', cost: 12000000, effect: 350),
+  ],
 };
 
 /// Creates a deep copy of the upgrade list for the given [tier].


### PR DESCRIPTION
## Summary
- make milestone thresholds much higher
- add new upgrades for later progression tiers
- expand staff roster so late game milestones have hire options

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684667336ffc8321b1d5567a847eb73d