### PR TITLE
Improve unlockable panel presentation

### DIFF
--- a/lib/widgets/staff_panel.dart
+++ b/lib/widgets/staff_panel.dart
@@ -40,9 +40,27 @@ class StaffPanel extends StatelessWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text('${s.name} ($owned hired)',
-                      style: Theme.of(context).textTheme.titleMedium),
-                  Text('Cost: ${s.cost} \u2014 ${s.tapsPerSecond} taps/s'),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(s.name,
+                            style: Theme.of(context).textTheme.titleMedium),
+                      ),
+                      Chip(label: Text('Hired: $owned')),
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+                  Row(
+                    children: [
+                      const Icon(Icons.attach_money, size: 16),
+                      const SizedBox(width: 4),
+                      Text('${s.cost}'),
+                      const SizedBox(width: 12),
+                      const Icon(Icons.timer, size: 16),
+                      const SizedBox(width: 4),
+                      Text('${s.tapsPerSecond} tps'),
+                    ],
+                  ),
                   const SizedBox(height: 8),
                   Row(
                     mainAxisAlignment: MainAxisAlignment.end,

--- a/lib/widgets/upgrade_panel.dart
+++ b/lib/widgets/upgrade_panel.dart
@@ -34,9 +34,27 @@ class UpgradePanel extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(u.name, style: Theme.of(context).textTheme.titleMedium),
-                Text(
-                    'Cost: \$${u.cost} - Effect: +${u.effect} per tap - Owned: ${u.owned}'),
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(u.name,
+                          style: Theme.of(context).textTheme.titleMedium),
+                    ),
+                    Chip(label: Text('Owned: ${u.owned}')),
+                  ],
+                ),
+                const SizedBox(height: 4),
+                Row(
+                  children: [
+                    const Icon(Icons.attach_money, size: 16),
+                    const SizedBox(width: 4),
+                    Text('${u.cost}'),
+                    const SizedBox(width: 12),
+                    const Icon(Icons.upgrade, size: 16),
+                    const SizedBox(width: 4),
+                    Text('+${u.effect}/tap'),
+                  ],
+                ),
                 const SizedBox(height: 8),
                 Row(
                   mainAxisAlignment: MainAxisAlignment.end,


### PR DESCRIPTION
## Summary
- add clear cost and owned indicators in upgrade panel
- show hired count and cost details in staff panel

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68466868698c8321bc03f514be9b9a8b