### PR TITLE
Improve milestone overlay layout

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -98,7 +98,7 @@ class _CounterPageState extends ConsumerState<CounterPage>
         context: context,
         barrierDismissible: false,
         barrierLabel: 'milestone',
-        barrierColor: Colors.white,
+        barrierColor: Colors.black54,
         transitionDuration: const Duration(milliseconds: 400),
         pageBuilder: (context, animation, secondaryAnimation) {
           return FadeTransition(

--- a/lib/widgets/milestone_overlay.dart
+++ b/lib/widgets/milestone_overlay.dart
@@ -31,41 +31,52 @@ class _MilestoneOverlayState extends State<MilestoneOverlay> {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: _canContinue ? widget.onContinue : null,
-      child: Container(
-        color: Colors.white,
-        alignment: Alignment.center,
-        padding: const EdgeInsets.all(24),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              widget.title,
-              style: Theme.of(context).textTheme.headlineSmall,
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 16),
-            Text(
-              widget.art,
-              textAlign: TextAlign.center,
-              style: const TextStyle(fontFamily: 'monospace'),
-            ),
-            const SizedBox(height: 16),
-            Text(
-              widget.dialogue,
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 24),
-            ElevatedButton(
-              onPressed: _canContinue ? widget.onContinue : null,
-              child: Text(
-                _canContinue
-                    ? 'Open new restaurant milestone'
-                    : 'Please wait...',
+    return Material(
+      color: Colors.transparent,
+      child: GestureDetector(
+        onTap: _canContinue ? widget.onContinue : null,
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 320),
+            child: Card(
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+              margin: const EdgeInsets.all(24),
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Text(
+                      widget.title,
+                      style: Theme.of(context).textTheme.headlineSmall,
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      widget.art,
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(fontFamily: 'monospace'),
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      widget.dialogue,
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 24),
+                    ElevatedButton(
+                      onPressed: _canContinue ? widget.onContinue : null,
+                      child: Text(
+                        _canContinue ? 'Continue' : 'Please wait...',
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
-          ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- redesign milestone overlay with a centered card layout
- dim background while the milestone overlay is shown

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68466b65a6c48321b8d2274ac24786ef