### PR TITLE
Rework prestige locations

### DIFF
--- a/lib/controllers/game_controller.dart
+++ b/lib/controllers/game_controller.dart
@@ -271,7 +271,7 @@ class GameController extends ChangeNotifier {
     game.resetProgress();
     game.prestige.points = 0;
     game.franchiseTokens = 0;
-    game.currentLocationIndex = 0;
+    game.locationSetIndex = 0;
     game.purchasedPrestigeUpgrades.clear();
     coins = 0;
     perTap = 1;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -277,8 +277,8 @@ class _CounterPageState extends ConsumerState<CounterPage>
     HapticFeedback.selectionClick();
     final tokens = 1 + (controller.game.mealsServed ~/ 1000);
     final nextIndex =
-        (controller.game.currentLocationIndex + 1) % franchiseProgression.length;
-    final nextName = franchiseProgression[nextIndex].name;
+        (controller.game.locationSetIndex + 1) % franchiseLocationSets.length;
+    final nextName = franchiseLocationSets[nextIndex][0].name;
     final confirm = await showDialog<bool>(
       context: context,
       builder: (_) => AlertDialog(

--- a/lib/models/franchise_location.dart
+++ b/lib/models/franchise_location.dart
@@ -10,15 +10,32 @@ class FranchiseLocation {
   });
 }
 
-const List<FranchiseLocation> franchiseProgression = [
-  FranchiseLocation(name: 'Nashville', tierName: 'City', artAsset: 'assets/images/nashville.png'),
-  FranchiseLocation(name: 'New York', tierName: 'City', artAsset: 'assets/images/new_york.png'),
-  FranchiseLocation(name: 'Tokyo', tierName: 'City', artAsset: 'assets/images/tokyo.png'),
+const List<String> franchiseTiers = ['City', 'Country', 'Planet'];
 
-  FranchiseLocation(name: 'USA', tierName: 'Country', artAsset: 'assets/images/usa.png'),
-  FranchiseLocation(name: 'Canada', tierName: 'Country', artAsset: 'assets/images/canada.png'),
-  FranchiseLocation(name: 'Japan', tierName: 'Country', artAsset: 'assets/images/japan.png'),
-
-  FranchiseLocation(name: 'Earth', tierName: 'Planet', artAsset: 'assets/images/earth.png'),
-  FranchiseLocation(name: 'Mars', tierName: 'Planet', artAsset: 'assets/images/mars.png'),
+/// Groups of [FranchiseLocation] names that rotate each prestige.
+const List<List<FranchiseLocation>> franchiseLocationSets = [
+  [
+    FranchiseLocation(
+        name: 'Nashville', tierName: 'City', artAsset: 'assets/images/nashville.png'),
+    FranchiseLocation(
+        name: 'USA', tierName: 'Country', artAsset: 'assets/images/usa.png'),
+    FranchiseLocation(
+        name: 'Earth', tierName: 'Planet', artAsset: 'assets/images/earth.png'),
+  ],
+  [
+    FranchiseLocation(
+        name: 'New York', tierName: 'City', artAsset: 'assets/images/new_york.png'),
+    FranchiseLocation(
+        name: 'Canada', tierName: 'Country', artAsset: 'assets/images/canada.png'),
+    FranchiseLocation(
+        name: 'Mars', tierName: 'Planet', artAsset: 'assets/images/mars.png'),
+  ],
+  [
+    FranchiseLocation(
+        name: 'Tokyo', tierName: 'City', artAsset: 'assets/images/tokyo.png'),
+    FranchiseLocation(
+        name: 'Japan', tierName: 'Country', artAsset: 'assets/images/japan.png'),
+    FranchiseLocation(
+        name: 'Venus', tierName: 'Planet', artAsset: 'assets/images/venus.png'),
+  ],
 ];

--- a/lib/models/game_state.dart
+++ b/lib/models/game_state.dart
@@ -9,13 +9,17 @@ class GameState extends ChangeNotifier {
   int milestoneIndex;
   final Prestige prestige;
   int franchiseTokens = 0;
-  int currentLocationIndex = 0;
+  int locationSetIndex = 0;
   Map<String, int> purchasedPrestigeUpgrades = {};
   List<String> ownedArtifactIds = [];
   List<String?> equippedArtifactIds = [null, null, null];
 
-  FranchiseLocation get currentLocation =>
-      franchiseProgression[currentLocationIndex];
+  int get locationTierIndex =>
+      (milestoneIndex * franchiseTiers.length) ~/ milestones.length;
+
+  FranchiseLocation get currentLocation => franchiseLocationSets[
+          locationSetIndex % franchiseLocationSets.length]
+      [locationTierIndex];
 
   GameState({this.mealsServed = 0, this.milestoneIndex = 0, Prestige? prestige})
       : prestige = prestige ?? Prestige();
@@ -65,8 +69,8 @@ class GameState extends ChangeNotifier {
     if (atFinalMilestone) {
       int tokensEarned = 1 + (mealsServed ~/ 1000);
       franchiseTokens += tokensEarned;
-      currentLocationIndex =
-          (currentLocationIndex + 1) % franchiseProgression.length;
+      locationSetIndex =
+          (locationSetIndex + 1) % franchiseLocationSets.length;
       resetProgress();
     }
   }

--- a/lib/services/storage.dart
+++ b/lib/services/storage.dart
@@ -12,7 +12,7 @@ class StorageService {
   static const _keyCount = 'count';
   static const _keyTimestamp = 'timestamp';
   static const _keyTokens = 'franchiseTokens';
-  static const _keyLocation = 'currentLocationIndex';
+  static const _keyLocation = 'locationSetIndex';
   static const _keyUpgrades = 'purchasedPrestigeUpgrades';
 
   /// Saves the current count and timestamp to local storage.
@@ -25,7 +25,7 @@ class StorageService {
   Future<void> saveFranchiseData(GameState game) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_keyTokens, game.franchiseTokens);
-    await prefs.setInt(_keyLocation, game.currentLocationIndex);
+    await prefs.setInt(_keyLocation, game.locationSetIndex);
     await prefs.setString(
         _keyUpgrades, jsonEncode(game.purchasedPrestigeUpgrades));
   }
@@ -33,7 +33,7 @@ class StorageService {
   Future<void> loadFranchiseData(GameState game) async {
     final prefs = await SharedPreferences.getInstance();
     game.franchiseTokens = prefs.getInt(_keyTokens) ?? 0;
-    game.currentLocationIndex = prefs.getInt(_keyLocation) ?? 0;
+    game.locationSetIndex = prefs.getInt(_keyLocation) ?? 0;
     final upgradesString = prefs.getString(_keyUpgrades);
     if (upgradesString != null && upgradesString.isNotEmpty) {
       final decoded = jsonDecode(upgradesString) as Map<String, dynamic>;

--- a/lib/widgets/franchise_hq.dart
+++ b/lib/widgets/franchise_hq.dart
@@ -16,6 +16,8 @@ class FranchiseHQ extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final upgrades = prestigeUpgrades.values.toList();
+    final locations =
+        franchiseLocationSets[game.locationSetIndex % franchiseLocationSets.length];
     return SingleChildScrollView(
       padding: const EdgeInsets.all(16),
       child: Column(
@@ -23,12 +25,12 @@ class FranchiseHQ extends StatelessWidget {
         children: [
           Text('Location Progression', style: Theme.of(context).textTheme.titleLarge),
           const SizedBox(height: 8),
-          ...franchiseProgression.map((loc) {
-            final index = franchiseProgression.indexOf(loc);
+          ...locations.map((loc) {
+            final index = locations.indexOf(loc);
             String status;
-            if (index < game.currentLocationIndex) {
+            if (index < game.locationTierIndex) {
               status = 'Completed';
-            } else if (index == game.currentLocationIndex) {
+            } else if (index == game.locationTierIndex) {
               status = 'Current';
             } else {
               status = 'Upcoming';


### PR DESCRIPTION
## Summary
- add tiers and location sets for rotating names
- update `GameState` for new location tier logic and prestige behavior
- persist `locationSetIndex` instead of `currentLocationIndex`
- adapt UI and reset flow for new system

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68466bd130b48321af12d06e99417f52