### PR TITLE
Implement persistent player state

### DIFF
--- a/lib/controllers/game_controller.dart
+++ b/lib/controllers/game_controller.dart
@@ -55,6 +55,15 @@ class GameController extends ChangeNotifier {
 
   Future<OfflineLoadResult> load() async {
     final result = await _storage.loadGame(idleMultiplier: 0.000833);
+    final player = await _storage.loadPlayerData();
+    coins = player.coins;
+    perTap = player.perTap;
+    hiredStaff
+      ..clear()
+      ..addAll(player.staff);
+    for (final u in upgrades) {
+      u.owned = player.upgrades[u.name] ?? 0;
+    }
     game.mealsServed = result.count;
     final adjustedEarned =
         effects.calculateOfflineEarnings(result.earned.toDouble()).toInt();
@@ -74,6 +83,12 @@ class GameController extends ChangeNotifier {
   Future<void> save() async {
     await _storage.saveGame(game.mealsServed);
     await _storage.saveFranchiseData(game);
+    await _storage.savePlayerData(
+      coins: coins,
+      perTap: perTap,
+      staff: hiredStaff,
+      upgrades: {for (final u in upgrades) u.name: u.owned},
+    );
   }
 
   void cook() {

--- a/lib/services/storage.dart
+++ b/lib/services/storage.dart
@@ -1,11 +1,26 @@
 import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../models/game_state.dart';
+import '../models/staff.dart';
 
 class OfflineLoadResult {
   final int count;
   final int earned;
   OfflineLoadResult(this.count, this.earned);
+}
+
+class PlayerData {
+  final int coins;
+  final int perTap;
+  final Map<StaffType, int> staff;
+  final Map<String, int> upgrades;
+
+  PlayerData({
+    required this.coins,
+    required this.perTap,
+    required this.staff,
+    required this.upgrades,
+  });
 }
 
 class StorageService {
@@ -14,6 +29,10 @@ class StorageService {
   static const _keyTokens = 'franchiseTokens';
   static const _keyLocation = 'locationSetIndex';
   static const _keyUpgrades = 'purchasedPrestigeUpgrades';
+  static const _keyCoins = 'coins';
+  static const _keyPerTap = 'perTap';
+  static const _keyStaff = 'hiredStaff';
+  static const _keyOwnedUpgrades = 'ownedUpgrades';
 
   /// Saves the current count and timestamp to local storage.
   Future<void> saveGame(int count) async {
@@ -30,6 +49,20 @@ class StorageService {
         _keyUpgrades, jsonEncode(game.purchasedPrestigeUpgrades));
   }
 
+  Future<void> savePlayerData({
+    required int coins,
+    required int perTap,
+    required Map<StaffType, int> staff,
+    required Map<String, int> upgrades,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_keyCoins, coins);
+    await prefs.setInt(_keyPerTap, perTap);
+    await prefs.setString(_keyStaff,
+        jsonEncode(staff.map((k, v) => MapEntry(k.name, v))));
+    await prefs.setString(_keyOwnedUpgrades, jsonEncode(upgrades));
+  }
+
   Future<void> loadFranchiseData(GameState game) async {
     final prefs = await SharedPreferences.getInstance();
     game.franchiseTokens = prefs.getInt(_keyTokens) ?? 0;
@@ -40,6 +73,28 @@ class StorageService {
       game.purchasedPrestigeUpgrades =
           decoded.map((key, value) => MapEntry(key, value as int));
     }
+  }
+
+  Future<PlayerData> loadPlayerData() async {
+    final prefs = await SharedPreferences.getInstance();
+    final coins = prefs.getInt(_keyCoins) ?? 0;
+    final perTap = prefs.getInt(_keyPerTap) ?? 1;
+    final staffStr = prefs.getString(_keyStaff);
+    Map<StaffType, int> staff = {};
+    if (staffStr != null && staffStr.isNotEmpty) {
+      final decoded = jsonDecode(staffStr) as Map<String, dynamic>;
+      staff = decoded.map((key, value) =>
+          MapEntry(StaffType.values.firstWhere((e) => e.name == key),
+              value as int));
+    }
+    final upgradeStr = prefs.getString(_keyOwnedUpgrades);
+    Map<String, int> upgrades = {};
+    if (upgradeStr != null && upgradeStr.isNotEmpty) {
+      final decoded = jsonDecode(upgradeStr) as Map<String, dynamic>;
+      upgrades = decoded.map((k, v) => MapEntry(k, v as int));
+    }
+    return PlayerData(
+        coins: coins, perTap: perTap, staff: staff, upgrades: upgrades);
   }
 
   /// Loads the saved count and applies idle earnings based on the time elapsed.
@@ -73,5 +128,9 @@ class StorageService {
     await prefs.remove(_keyTokens);
     await prefs.remove(_keyLocation);
     await prefs.remove(_keyUpgrades);
+    await prefs.remove(_keyCoins);
+    await prefs.remove(_keyPerTap);
+    await prefs.remove(_keyStaff);
+    await prefs.remove(_keyOwnedUpgrades);
   }
 }

--- a/test/game_controller_persistence_test.dart
+++ b/test/game_controller_persistence_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:taptapchef/controllers/game_controller.dart';
+import 'package:taptapchef/models/staff.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('saved game restores coins, staff and upgrades', () async {
+    SharedPreferences.setMockInitialValues({});
+    final controller = GameController();
+    controller.coins = 42;
+    controller.perTap = 3;
+    controller.hiredStaff[StaffType.tacoFlipper] = 2;
+    controller.upgrades.first.owned = 1;
+    await controller.save();
+
+    final controller2 = GameController();
+    await controller2.load();
+
+    expect(controller2.coins, 42);
+    expect(controller2.perTap, 3);
+    expect(controller2.hiredStaff[StaffType.tacoFlipper], 2);
+    expect(controller2.upgrades.first.owned, 1);
+  });
+}
+


### PR DESCRIPTION
## Summary
- expand `StorageService` with new keys and methods
- persist coins, staff hires and upgrade ownership
- wire persistence into `GameController`
- test saving and loading of player state

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68466f800c088321a654870d0a4267c4