### PR TITLE
Fix resetGame state cleanup

### DIFF
--- a/lib/controllers/game_controller.dart
+++ b/lib/controllers/game_controller.dart
@@ -299,6 +299,25 @@ class GameController extends ChangeNotifier {
     _passiveProgress = 0;
     _lastMilestoneIndex = 0;
     currentTPS = 0;
+    // Reset temporary gameplay state
+    specialVisible = false;
+    combo = 0;
+    frenzy = false;
+    adBoostActive = false;
+    adBoostSeconds = 0;
+    ripMode = false;
+
+    // Cancel any running timers associated with these states
+    comboTimer?.cancel();
+    comboTimer = null;
+    frenzyWarmupTimer?.cancel();
+    frenzyWarmupTimer = null;
+    frenzyDurationTimer?.cancel();
+    frenzyDurationTimer = null;
+    adBoostTimer?.cancel();
+    adBoostTimer = null;
+    ripTimer?.cancel();
+    ripTimer = null;
     notifyListeners();
   }
 

--- a/test/reset_game_test.dart
+++ b/test/reset_game_test.dart
@@ -1,0 +1,35 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:taptapchef/controllers/game_controller.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('resetGame clears temporary state and timers', () async {
+    SharedPreferences.setMockInitialValues({});
+    final controller = GameController();
+
+    // Simulate various active states
+    controller.specialVisible = true;
+    controller.startAdBoost();
+    controller.ripMode = true;
+    controller.ripTimer = Timer(const Duration(seconds: 1), () {});
+    controller.cook(); // start combo timer
+
+    await controller.resetGame();
+
+    expect(controller.specialVisible, isFalse);
+    expect(controller.combo, 0);
+    expect(controller.frenzy, isFalse);
+    expect(controller.adBoostActive, isFalse);
+    expect(controller.ripMode, isFalse);
+
+    expect(controller.comboTimer, isNull);
+    expect(controller.frenzyWarmupTimer, isNull);
+    expect(controller.frenzyDurationTimer, isNull);
+    expect(controller.adBoostTimer, isNull);
+    expect(controller.ripTimer, isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- reset transient gameplay flags when resetting game
- cancel timers related to combo, frenzy, ad boost and rip mode
- test resetGame to verify timers and state are cleared

## Testing
- `flutter --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_684672adc1708321b82e0cb1f4de7db3