### PR TITLE
Implement remaining artifact effects

### DIFF
--- a/lib/controllers/effect_engine.dart
+++ b/lib/controllers/effect_engine.dart
@@ -93,4 +93,75 @@ class EffectEngine {
     }
     return value;
   }
+
+  double calculateEventReward(double baseReward) {
+    double value = baseReward;
+    for (final art in _equipped) {
+      for (final effect in [art.bonus, art.drawback]) {
+        if (effect.type == ArtifactEffectType.eventRewardMultiplier) {
+          value *= effect.value;
+        }
+      }
+    }
+    return value;
+  }
+
+  double adjustGoldenMealChance(double baseChance) {
+    double chance = baseChance;
+    for (final art in _equipped) {
+      for (final effect in [art.bonus, art.drawback]) {
+        if (effect.type == ArtifactEffectType.goldenMealChance) {
+          chance += effect.value;
+        }
+      }
+    }
+    return chance;
+  }
+
+  double calculateGoldenMealReward(double baseReward) {
+    double value = baseReward;
+    for (final art in _equipped) {
+      for (final effect in [art.bonus, art.drawback]) {
+        if (effect.type == ArtifactEffectType.goldenMealMultiplier) {
+          value *= effect.value;
+        }
+      }
+    }
+    return value;
+  }
+
+  int totalFreePurchases() {
+    int total = 0;
+    for (final art in _equipped) {
+      for (final effect in [art.bonus, art.drawback]) {
+        if (effect.type == ArtifactEffectType.firstPurchasesFree) {
+          total += effect.value.toInt();
+        }
+      }
+    }
+    return total;
+  }
+
+  double calculateTapPassiveSeconds(double baseSeconds) {
+    double seconds = baseSeconds;
+    for (final art in _equipped) {
+      for (final effect in [art.bonus, art.drawback]) {
+        if (effect.type == ArtifactEffectType.tapTriggerPassiveSeconds) {
+          seconds += effect.value;
+        }
+      }
+    }
+    return seconds;
+  }
+
+  bool get singleStaffTypeOnly {
+    for (final art in _equipped) {
+      for (final effect in [art.bonus, art.drawback]) {
+        if (effect.type == ArtifactEffectType.singleStaffTypeOnly) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
 }

--- a/lib/models/artifact.dart
+++ b/lib/models/artifact.dart
@@ -155,4 +155,15 @@ final Map<String, Artifact> gameArtifacts = {
     drawback:
         ArtifactEffect(type: ArtifactEffectType.tapValueDebuff, value: 0.0),
   ),
+  'gold_plated_plate': const Artifact(
+    id: 'gold_plated_plate',
+    name: 'Gold-Plated Plate',
+    description:
+        'Transforms lucky dishes into riches, but makes events less rewarding.',
+    iconAsset: 'assets/icons/gold_plated_plate.png',
+    bonus:
+        ArtifactEffect(type: ArtifactEffectType.goldenMealMultiplier, value: 2.0),
+    drawback:
+        ArtifactEffect(type: ArtifactEffectType.eventRewardMultiplier, value: 0.5),
+  ),
 };

--- a/test/effect_engine_test.dart
+++ b/test/effect_engine_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:taptapchef/controllers/effect_engine.dart';
+import 'package:taptapchef/models/game_state.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('event rewards are multiplied by equipped artifacts', () {
+    final game = GameState();
+    game.equippedArtifactIds[0] = 'lucky_ladle';
+    final engine = EffectEngine(game);
+    expect(engine.calculateEventReward(100), 150);
+  });
+
+  test('golden meal effects combine correctly', () {
+    final game = GameState();
+    game.equippedArtifactIds[0] = 'golden_spatula';
+    game.equippedArtifactIds[1] = 'gold_plated_plate';
+    final engine = EffectEngine(game);
+    expect(engine.adjustGoldenMealChance(0.05), closeTo(0.06, 0.0001));
+    expect(engine.calculateGoldenMealReward(10), 20);
+  });
+
+  test('first purchases and staff restriction flags', () {
+    final game = GameState();
+    game.equippedArtifactIds[0] = 'suppliers_handshake';
+    game.equippedArtifactIds[1] = 'minimalist_menu';
+    final engine = EffectEngine(game);
+    expect(engine.totalFreePurchases(), 10);
+    expect(engine.singleStaffTypeOnly, isTrue);
+  });
+
+  test('tap triggers passive progress seconds', () {
+    final game = GameState();
+    game.equippedArtifactIds[0] = 'head_chef_loudspeaker';
+    final engine = EffectEngine(game);
+    expect(engine.calculateTapPassiveSeconds(0), 300);
+  });
+}


### PR DESCRIPTION
## Summary
- support all `ArtifactEffectType` values in `EffectEngine`
- add a new `gold_plated_plate` artifact using a new effect
- cover artifact effects with unit tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68467394103c8321a9ad42b311c17579