### PR TITLE
Adjust progression math and number formatting

### DIFF
--- a/game_design_doc.md
+++ b/game_design_doc.md
@@ -74,6 +74,17 @@
 
 ---
 
+## 📊 Progression Math Review
+
+- **Base milestone goals** follow a gentler curve: `4.8k`, `24k`, `72k`,
+  `144k`, `288k`, `480k`, `960k`, `2.4m`.
+- After signing a **Franchise Deal**, milestone goals are only **2%** of these
+  values so players can breeze through early tiers with just a few taps.
+- All large numbers in the UI are displayed using short formats
+  (`1k`, `5m`, `5b`, `5q`, etc.).
+
+---
+
 ## 🔓 Upgrade Trees
 
 | Category     | Examples                                  |

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,6 +24,7 @@ import 'widgets/franchise_hq.dart';
 import 'constants/milestones.dart';
 import 'constants/panels.dart';
 import 'models/game_state.dart';
+import 'util/format.dart';
 
 void main() => runApp(const ProviderScope(child: MyApp()));
 
@@ -318,9 +319,8 @@ class _CounterPageState extends ConsumerState<CounterPage>
   @override
   Widget build(BuildContext context) {
     final bool finalStage = controller.game.atFinalMilestone;
-    final int goal = finalStage
-        ? 0
-        : GameState.milestoneGoals[controller.game.milestoneIndex];
+    final int goal =
+        finalStage ? 0 : controller.game.currentMilestoneGoal;
     final double progress =
         finalStage ? 1 : controller.game.mealsServed / goal;
     final String nextName = finalStage
@@ -362,9 +362,9 @@ class _CounterPageState extends ConsumerState<CounterPage>
                     children: [
                       Text('Current Location: ${controller.game.currentLocation.name}',
                           style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
-                      Text('Franchise Tokens: ${controller.game.franchiseTokens}'),
+                      Text('Franchise Tokens: ${formatNumber(controller.game.franchiseTokens)}'),
                       const SizedBox(height: 8),
-                      Text('Meals served: ${controller.game.mealsServed}'),
+                      Text('Meals served: ${formatNumber(controller.game.mealsServed)}'),
                       Text('Stage: ${controller.game.currentMilestone}'),
                       LinearProgressIndicator(value: progress),
                       Text(finalStage
@@ -405,7 +405,7 @@ class _CounterPageState extends ConsumerState<CounterPage>
                           ),
                         ),
                       const SizedBox(height: 24),
-                      Text('Coins: ${controller.coins}'),
+                      Text('Coins: ${formatNumber(controller.coins)}'),
                       const SizedBox(height: 16),
                       UpgradePanel(
                         upgrades: controller.upgrades,

--- a/lib/models/game_state.dart
+++ b/lib/models/game_state.dart
@@ -35,7 +35,7 @@ class GameState extends ChangeNotifier {
     'Multiverse Franchise'
   ];
 
-  static const List<int> milestoneGoals = [
+  static const List<int> baseMilestoneGoals = [
     4800,
     24000,
     72000,
@@ -46,13 +46,24 @@ class GameState extends ChangeNotifier {
     2400000
   ];
 
+  /// Returns the milestone goal for [index] taking prestige bonuses into
+  /// account. After the player has franchised at least once, goals are
+  /// dramatically reduced to allow very quick progress through early tiers.
+  int milestoneGoalAt(int index) {
+    final base = baseMilestoneGoals[index];
+    final scale = franchiseTokens > 0 ? 0.02 : 1.0;
+    return (base * scale).ceil();
+  }
+
+  int get currentMilestoneGoal => milestoneGoalAt(milestoneIndex);
+
   String get currentMilestone => milestones[milestoneIndex];
 
   bool get atFinalMilestone => milestoneIndex >= milestones.length - 1;
 
   void cook() {
     mealsServed += prestige.multiplier.ceil();
-    if (!atFinalMilestone && mealsServed >= milestoneGoals[milestoneIndex]) {
+    if (!atFinalMilestone && mealsServed >= currentMilestoneGoal) {
       milestoneIndex++;
       mealsServed = 0;
     }

--- a/lib/util/format.dart
+++ b/lib/util/format.dart
@@ -1,0 +1,14 @@
+/// Utility for displaying large numbers using short suffixes.
+String formatNumber(num number) {
+  if (number < 1000) return number.toString();
+  const suffixes = ['k', 'm', 'b', 't', 'q'];
+  double value = number.toDouble();
+  int i = 0;
+  while (value >= 1000 && i < suffixes.length) {
+    value /= 1000;
+    i++;
+  }
+  final text = value.toStringAsFixed(value < 10 ? 1 : 0);
+  return '$text${suffixes[i - 1]}';
+}
+

--- a/lib/widgets/franchise_hq.dart
+++ b/lib/widgets/franchise_hq.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../models/game_state.dart';
 import '../models/franchise_location.dart';
 import '../models/prestige_upgrade.dart';
+import '../util/format.dart';
 
 class FranchiseHQ extends StatelessWidget {
   final GameState game;
@@ -51,7 +52,7 @@ class FranchiseHQ extends StatelessWidget {
             final canBuy = !maxed && game.franchiseTokens >= cost;
             return ListTile(
               title: Text(u.name),
-              subtitle: Text('${u.description}\nLevel: $level/${u.maxLevel} - Cost: ${maxed ? 'MAX' : cost}'),
+              subtitle: Text('${u.description}\nLevel: $level/${u.maxLevel} - Cost: ${maxed ? 'MAX' : formatNumber(cost)}'),
               trailing: maxed
                   ? const Icon(Icons.check, color: Colors.green)
                   : ElevatedButton(

--- a/lib/widgets/offline_earnings_dialog.dart
+++ b/lib/widgets/offline_earnings_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../util/format.dart';
 
 class OfflineEarningsDialog extends StatelessWidget {
   final int earned;
@@ -16,7 +17,7 @@ class OfflineEarningsDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     return AlertDialog(
       title: const Text('Welcome Back!'),
-      content: Text('You earned $earned coins while you were away.'),
+      content: Text('You earned ${formatNumber(earned)} coins while you were away.'),
       actions: [
         TextButton(onPressed: onClose, child: const Text('Nice')),
         TextButton(onPressed: onDouble, child: const Text('Double for Ad')),

--- a/lib/widgets/staff_panel.dart
+++ b/lib/widgets/staff_panel.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/staff.dart';
 import 'pulse.dart';
+import '../util/format.dart';
 
 /// A panel for hiring staff using the same layout as [UpgradePanel].
 class StaffPanel extends StatelessWidget {
@@ -54,7 +55,7 @@ class StaffPanel extends StatelessWidget {
                     children: [
                       const Icon(Icons.attach_money, size: 16),
                       const SizedBox(width: 4),
-                      Text('${s.cost}'),
+                      Text(formatNumber(s.cost)),
                       const SizedBox(width: 12),
                       const Icon(Icons.timer, size: 16),
                       const SizedBox(width: 4),

--- a/lib/widgets/upgrade_panel.dart
+++ b/lib/widgets/upgrade_panel.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/upgrade.dart';
 import 'pulse.dart';
+import '../util/format.dart';
 
 
 class UpgradePanel extends StatelessWidget {
@@ -48,7 +49,7 @@ class UpgradePanel extends StatelessWidget {
                   children: [
                     const Icon(Icons.attach_money, size: 16),
                     const SizedBox(width: 4),
-                    Text('${u.cost}'),
+                    Text(formatNumber(u.cost)),
                     const SizedBox(width: 12),
                     const Icon(Icons.upgrade, size: 16),
                     const SizedBox(width: 4),

--- a/test/game_state_test.dart
+++ b/test/game_state_test.dart
@@ -4,7 +4,7 @@ import 'package:taptapchef/models/game_state.dart';
 void main() {
   test('milestone progresses when goal reached', () {
     final game = GameState();
-    for (var i = 0; i < GameState.milestoneGoals[0]; i++) {
+    for (var i = 0; i < game.milestoneGoalAt(0); i++) {
       game.cook();
     }
     expect(game.milestoneIndex, 1);


### PR DESCRIPTION
## Summary
- flatten milestone curve after franchising
- show large numbers using short format (1k, 5m, etc.)
- document new math approach

## Testing
- `apt-get update`
- (tests and formatting skipped: Flutter not installed)

------
https://chatgpt.com/codex/tasks/task_e_68467c21fcec832196ca83296e4d79a7