### PR TITLE
Add progression tiers and test scaling

### DIFF
--- a/lib/models/progression.dart
+++ b/lib/models/progression.dart
@@ -41,4 +41,14 @@ const List<ProgressionTier> progressionTiers = [
     unlockRequirement: 300000,
     reward: 'Black hole catering, existential AI',
   ),
+  ProgressionTier(
+    name: 'Time Warp Kitchen',
+    unlockRequirement: 600000,
+    reward: 'Temporal upgrades, time-loop menus',
+  ),
+  ProgressionTier(
+    name: 'Multiverse Franchise',
+    unlockRequirement: 1200000,
+    reward: 'Reality-hopping logistics',
+  ),
 ];

--- a/test/game_state_test.dart
+++ b/test/game_state_test.dart
@@ -10,4 +10,16 @@ void main() {
     expect(game.milestoneIndex, 1);
     expect(game.mealsServed, 0);
   });
+
+  test('milestone goals scale down after franchising', () {
+    final game = GameState();
+    game.franchiseTokens = 1;
+
+    final baseGoal = GameState.baseMilestoneGoals.first;
+    expect(game.milestoneGoalAt(0), (baseGoal * 0.02).ceil());
+
+    final lastBaseGoal = GameState.baseMilestoneGoals.last;
+    expect(game.milestoneGoalAt(GameState.baseMilestoneGoals.length - 1),
+        (lastBaseGoal * 0.02).ceil());
+  });
 }


### PR DESCRIPTION
## Summary
- implement Time Warp Kitchen and Multiverse Franchise tiers
- add a test for franchise milestone scaling

## Testing
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b112d82548321b30ac11043e85a37