### PR TITLE
Update combo/frenzy mechanics

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Inspired by **Egg, Inc.** and **Universal Paperclips**, Tap Tap Chef balances a 
 ### Basic Loop:
 - **Tap to Cook** – Taps = meals served = cash.
 - **Build Combos** – Rapid taps raise a combo meter for extra earnings. It now
-  takes **20 taps** to fill the meter.
+  takes **30 taps** to fill the meter.
 - **Frenzy Mode** – Max the meter for a short burst of huge profits. During
   Frenzy a fiery overlay gradually rises from the bottom of the screen.
 - **Special Customers** – Occasionally a VIP pops up. Tap them for mini-games or temporary boosts.

--- a/test/game_mechanics_test.dart
+++ b/test/game_mechanics_test.dart
@@ -7,22 +7,30 @@ import 'package:taptapchef/models/staff.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test('combo timer decreases after timeout', () {
+  test('combo decreases gradually after inactivity', () {
     SharedPreferences.setMockInitialValues({});
     fakeAsync((async) {
       final controller = GameController();
 
-      controller.cook();
-      async.elapse(const Duration(seconds: 1));
-      controller.cook();
+      for (var i = 0; i < 5; i++) {
+        controller.cook();
+      }
 
-      async.elapse(GameController.comboTimeout + const Duration(milliseconds: 1));
+      expect(controller.combo, 5);
+
+      async.elapse(const Duration(seconds: 1));
+      expect(controller.combo, 4);
+
+      async.elapse(const Duration(seconds: 3));
+      expect(controller.combo, 1);
+
+      async.elapse(const Duration(seconds: 1));
       expect(controller.combo, 0);
-      expect(controller.comboTimer!.isActive, isFalse);
+      expect(controller.comboTimer, isNull);
     });
   });
 
-  test('frenzy activates after warmup and ends after duration', () {
+  test('frenzy activates immediately and ends after duration', () {
     SharedPreferences.setMockInitialValues({});
     fakeAsync((async) {
       final controller = GameController();
@@ -32,10 +40,6 @@ void main() {
       }
 
       expect(controller.combo, GameController.comboMax);
-      expect(controller.frenzy, isFalse);
-      expect(controller.frenzyWarmupTimer, isNotNull);
-
-      async.elapse(const Duration(seconds: 1));
       expect(controller.frenzy, isTrue);
       expect(controller.frenzyDurationTimer, isNotNull);
 

--- a/test/reset_game_test.dart
+++ b/test/reset_game_test.dart
@@ -27,7 +27,6 @@ void main() {
     expect(controller.ripMode, isFalse);
 
     expect(controller.comboTimer, isNull);
-    expect(controller.frenzyWarmupTimer, isNull);
     expect(controller.frenzyDurationTimer, isNull);
     expect(controller.adBoostTimer, isNull);
     expect(controller.ripTimer, isNull);


### PR DESCRIPTION
## Summary
- make the combo meter harder to fill and decay gradually
- trigger frenzy immediately when combo meter is full
- update documentation and tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e6ccddf083219495c2209404c2af