### PR TITLE
Extend game progression

### DIFF
--- a/game_design_doc.md
+++ b/game_design_doc.md
@@ -71,13 +71,16 @@
 | Endgame      | Black hole catering, existential AI | “Conceptual hunger”       |
 | Time Warp Kitchen | Temporal upgrades, time-loop menus | Chrono-chili |
 | Multiverse Franchise | Reality-hopping logistics | Schrödinger's soufflé |
+| Quantum Cafeteria | Particles serve themselves | Quark quiche |
+| Cosmic Supperclub | Guests arrive from lightyears away | Nebula noodles |
+| Omniversal Eatery | Reality on the menu | Infinity ice cream |
 
 ---
 
 ## 📊 Progression Math Review
 
 - **Base milestone goals** follow a gentler curve: `4.8k`, `24k`, `72k`,
-  `144k`, `288k`, `480k`, `960k`, `2.4m`.
+  `144k`, `288k`, `480k`, `960k`, `2.4m`, `4.8m`, `9.6m`, `19.2m`.
 - After signing a **Franchise Deal**, milestone goals are only **2%** of these
   values so players can breeze through early tiers with just a few taps.
 - All large numbers in the UI are displayed using short formats

--- a/lib/constants/milestones.dart
+++ b/lib/constants/milestones.dart
@@ -40,9 +40,24 @@ const List<String> milestoneArt = [
   /||\\
   ''',
   r'''
-   *-|-*
+  *-|-*
   /o\\
   \\v/
+  ''',
+  r'''
+  [@@]
+  /||\\
+   /\\
+  ''',
+  r'''
+  {**}
+  <||>
+  /__\\
+  ''',
+  r'''
+  |-O-|
+  / \\
+  \\ /
   ''',
 ];
 
@@ -55,4 +70,7 @@ const List<String> milestoneDialogues = [
   "You've fed the galaxy. Nothing left but existential hunger.",
   "Time loops around the kitchen. Omelettes now cause deja vu.",
   "The multiverse demands endless specials. Hope you're not out of ideas.",
+  "Quantum diners appear before they exist. That's efficient!",
+  "Cosmic beings book tables centuries in advance.",
+  "You serve reality itself. Taste is subjective.",
 ];

--- a/lib/constants/panels.dart
+++ b/lib/constants/panels.dart
@@ -7,6 +7,9 @@ const List<String> upgradePanelTitles = [
   'Endgame Upgrades',
   'Temporal Adjustments',
   'Multiverse Investments',
+  'Quantum Enhancements',
+  'Cosmic Expansions',
+  'Omniversal Upgrades',
 ];
 
 const List<String> hirePanelTitles = [
@@ -18,4 +21,7 @@ const List<String> hirePanelTitles = [
   'Endgame Operatives',
   'Temporal Staff',
   'Multiverse Talent',
+  'Quantum Crew',
+  'Cosmic Staff',
+  'Omniversal Team',
 ];

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,6 +22,7 @@ import 'widgets/milestone_overlay.dart';
 import 'models/franchise_location.dart';
 import 'widgets/franchise_hq.dart';
 import 'widgets/artifact_pantry.dart';
+import 'widgets/progression_sheet.dart';
 import 'constants/milestones.dart';
 import 'constants/panels.dart';
 import 'models/game_state.dart';
@@ -258,6 +259,17 @@ class _CounterPageState extends ConsumerState<CounterPage>
     ).then((_) => setState(() {}));
   }
 
+  void _showProgressionSheet() {
+    HapticFeedback.selectionClick();
+    showModalBottomSheet(
+      context: context,
+      builder: (_) => ProgressionSheet(
+        currentTier: controller.game.milestoneIndex,
+        currentProgress: controller.game.mealsServed,
+      ),
+    );
+  }
+
   Future<void> _resetGame() async {
     await controller.resetGame();
   }
@@ -435,6 +447,11 @@ class _CounterPageState extends ConsumerState<CounterPage>
                       ElevatedButton(
                         onPressed: _showPantry,
                         child: const Text('The Pantry'),
+                      ),
+                      const SizedBox(height: 8),
+                      ElevatedButton(
+                        onPressed: _showProgressionSheet,
+                        child: const Text('Progression'),
                       ),
                     ],
                   ),

--- a/lib/models/game_state.dart
+++ b/lib/models/game_state.dart
@@ -32,7 +32,10 @@ class GameState extends ChangeNotifier {
     'Space Empire',
     'Endgame',
     'Time Warp Kitchen',
-    'Multiverse Franchise'
+    'Multiverse Franchise',
+    'Quantum Cafeteria',
+    'Cosmic Supperclub',
+    'Omniversal Eatery'
   ];
 
   static const List<int> baseMilestoneGoals = [
@@ -43,7 +46,10 @@ class GameState extends ChangeNotifier {
     288000,
     480000,
     960000,
-    2400000
+    2400000,
+    4800000,
+    9600000,
+    19200000
   ];
 
   /// Returns the milestone goal for [index] taking prestige bonuses into

--- a/lib/models/progression.dart
+++ b/lib/models/progression.dart
@@ -51,4 +51,19 @@ const List<ProgressionTier> progressionTiers = [
     unlockRequirement: 1200000,
     reward: 'Reality-hopping logistics',
   ),
+  ProgressionTier(
+    name: 'Quantum Cafeteria',
+    unlockRequirement: 2400000,
+    reward: 'Particles serve themselves',
+  ),
+  ProgressionTier(
+    name: 'Cosmic Supperclub',
+    unlockRequirement: 4800000,
+    reward: 'Guests arrive from lightyears away',
+  ),
+  ProgressionTier(
+    name: 'Omniversal Eatery',
+    unlockRequirement: 9600000,
+    reward: 'Reality itself is on the menu',
+  ),
 ];

--- a/lib/models/staff.dart
+++ b/lib/models/staff.dart
@@ -114,4 +114,16 @@ const Map<int, Map<StaffType, Staff>> staffByTier = {
     StaffType.multiverseManager: _multiverseManager,
     StaffType.realityServer: _realityServer,
   },
+  8: {
+    StaffType.multiverseManager: _multiverseManager,
+    StaffType.realityServer: _realityServer,
+  },
+  9: {
+    StaffType.multiverseManager: _multiverseManager,
+    StaffType.realityServer: _realityServer,
+  },
+ 10: {
+    StaffType.multiverseManager: _multiverseManager,
+    StaffType.realityServer: _realityServer,
+  },
 };

--- a/lib/models/upgrade.dart
+++ b/lib/models/upgrade.dart
@@ -60,6 +60,21 @@ final Map<int, List<Upgrade>> upgradesByTier = {
     Upgrade(name: 'Infinite Menu Generator', cost: 10000000, effect: 300),
     Upgrade(name: 'Reality Distortion Service', cost: 12000000, effect: 350),
   ],
+  8: [
+    Upgrade(name: 'Quantum Entanglement Oven', cost: 14000000, effect: 400),
+    Upgrade(name: 'Dark Matter Marinade', cost: 18000000, effect: 450),
+    Upgrade(name: 'Teleport Delivery', cost: 22000000, effect: 500),
+  ],
+  9: [
+    Upgrade(name: 'Cosmic Catering', cost: 28000000, effect: 550),
+    Upgrade(name: 'Galaxy Infusion Lab', cost: 34000000, effect: 600),
+    Upgrade(name: 'Gravity-Free Dining', cost: 40000000, effect: 650),
+  ],
+ 10: [
+    Upgrade(name: 'Reality Rewrite Kitchen', cost: 50000000, effect: 700),
+    Upgrade(name: 'Omniversal Reservations', cost: 60000000, effect: 800),
+    Upgrade(name: 'Existence Flavour Enhancer', cost: 75000000, effect: 900),
+  ],
 };
 
 /// Creates a deep copy of the upgrade list for the given [tier].

--- a/lib/widgets/progression_sheet.dart
+++ b/lib/widgets/progression_sheet.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import '../models/progression.dart';
+import '../util/format.dart';
+
+class ProgressionSheet extends StatelessWidget {
+  final int currentTier;
+  final int currentProgress;
+
+  const ProgressionSheet({
+    super.key,
+    required this.currentTier,
+    required this.currentProgress,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      padding: const EdgeInsets.all(16),
+      itemCount: progressionTiers.length,
+      itemBuilder: (context, index) {
+        final tier = progressionTiers[index];
+        final status = index < currentTier
+            ? 'Completed'
+            : index == currentTier
+                ? 'Current'
+                : 'Locked';
+        double progress = 0;
+        if (index == currentTier && tier.unlockRequirement > 0) {
+          progress = currentProgress / tier.unlockRequirement;
+          if (progress > 1) progress = 1;
+        } else if (index < currentTier) {
+          progress = 1;
+        }
+        return ListTile(
+          leading: Icon(
+            index < currentTier
+                ? Icons.check_circle
+                : index == currentTier
+                    ? Icons.radio_button_checked
+                    : Icons.lock,
+          ),
+          title: Text(tier.name),
+          subtitle: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('${tier.reward}\nUnlocks at ${formatNumber(tier.unlockRequirement)} meals'),
+              LinearProgressIndicator(value: progress),
+            ],
+          ),
+          trailing: Text(status),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add new milestone tiers and goals
- update milestone art, dialogues, and panel titles
- add new upgrades and staff tiers
- introduce a Progression menu to track advancement

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e7ffa970832193f48fda980a5755