### PR TITLE
Make milestone overlay full screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -104,7 +104,7 @@ class _CounterPageState extends ConsumerState<CounterPage>
         context: context,
         barrierDismissible: false,
         barrierLabel: 'milestone',
-        barrierColor: Colors.black54,
+        barrierColor: Colors.black87,
         transitionDuration: const Duration(milliseconds: 400),
         pageBuilder: (context, animation, secondaryAnimation) {
           return FadeTransition(

--- a/lib/widgets/milestone_overlay.dart
+++ b/lib/widgets/milestone_overlay.dart
@@ -18,62 +18,90 @@ class MilestoneOverlay extends StatefulWidget {
   State<MilestoneOverlay> createState() => _MilestoneOverlayState();
 }
 
-class _MilestoneOverlayState extends State<MilestoneOverlay> {
+class _MilestoneOverlayState extends State<MilestoneOverlay>
+    with SingleTickerProviderStateMixin {
   bool _canContinue = false;
+  late final AnimationController _controller;
 
   @override
   void initState() {
     super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 600),
+    )..forward();
     Future.delayed(const Duration(seconds: 2), () {
       if (mounted) setState(() => _canContinue = true);
     });
   }
 
   @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return Material(
       color: Colors.transparent,
       child: GestureDetector(
         onTap: _canContinue ? widget.onContinue : null,
-        child: Center(
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 320),
-            child: Card(
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
-              ),
-              margin: const EdgeInsets.all(24),
-              child: Padding(
-                padding: const EdgeInsets.all(24),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    Text(
-                      widget.title,
-                      style: Theme.of(context).textTheme.headlineSmall,
-                      textAlign: TextAlign.center,
+        child: Container(
+          decoration: const BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: [Color(0xFF4527A0), Colors.black],
+            ),
+          ),
+          alignment: Alignment.center,
+          child: ScaleTransition(
+            scale: CurvedAnimation(
+              parent: _controller,
+              curve: Curves.easeOutBack,
+            ),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 32.0),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Text(
+                    widget.title,
+                    style: theme.textTheme.headlineMedium?.copyWith(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
                     ),
-                    const SizedBox(height: 16),
-                    Text(
-                      widget.art,
-                      textAlign: TextAlign.center,
-                      style: const TextStyle(fontFamily: 'monospace'),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 24),
+                  Text(
+                    widget.art,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      fontFamily: 'monospace',
+                      fontSize: 24,
+                      color: Colors.white,
                     ),
-                    const SizedBox(height: 16),
-                    Text(
-                      widget.dialogue,
-                      textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 24),
+                  Text(
+                    widget.dialogue,
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      color: Colors.white,
                     ),
-                    const SizedBox(height: 24),
-                    ElevatedButton(
-                      onPressed: _canContinue ? widget.onContinue : null,
-                      child: Text(
-                        _canContinue ? 'Continue' : 'Please wait...',
-                      ),
+                  ),
+                  const SizedBox(height: 32),
+                  ElevatedButton(
+                    onPressed: _canContinue ? widget.onContinue : null,
+                    child: Text(
+                      _canContinue ? 'Continue' : 'Please wait...',
                     ),
-                  ],
-                ),
+                  ),
+                ],
               ),
             ),
           ),


### PR DESCRIPTION
## Summary
- add an animated full-screen MilestoneOverlay
- darken overlay background in main dialog

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e9d5d0108321829e9b7582923aed