### PR TITLE
Improve progression and franchise reset

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -323,7 +323,8 @@ class _CounterPageState extends ConsumerState<CounterPage>
       ),
     );
     if (confirm == true) {
-      setState(() => controller.game.prestigeUp());
+      await controller.franchise();
+      setState(() {});
     }
   }
 

--- a/lib/models/game_state.dart
+++ b/lib/models/game_state.dart
@@ -39,25 +39,25 @@ class GameState extends ChangeNotifier {
   ];
 
   static const List<int> baseMilestoneGoals = [
-    4800,
-    24000,
-    72000,
-    144000,
-    288000,
-    480000,
-    960000,
-    2400000,
+    48000,
+    240000,
+    720000,
+    1440000,
+    2880000,
     4800000,
     9600000,
-    19200000
+    24000000,
+    48000000,
+    96000000,
+    192000000
   ];
 
   /// Returns the milestone goal for [index] taking prestige bonuses into
   /// account. After the player has franchised at least once, goals are
-  /// dramatically reduced to allow very quick progress through early tiers.
+  /// reduced but still require effort to progress through early tiers.
   int milestoneGoalAt(int index) {
     final base = baseMilestoneGoals[index];
-    final scale = franchiseTokens > 0 ? 0.02 : 1.0;
+    final scale = franchiseTokens > 0 ? 0.5 : 1.0;
     return (base * scale).ceil();
   }
 

--- a/lib/models/staff.dart
+++ b/lib/models/staff.dart
@@ -28,37 +28,37 @@ class Staff {
 
 // Individual staff definitions so they can be reused across tier maps.
 const Staff _tacoFlipper =
-    Staff(name: 'Taco Flipper', cost: 50, tapsPerSecond: 0.3);
+    Staff(name: 'Taco Flipper', cost: 250, tapsPerSecond: 0.6);
 const Staff _flyerHandout =
-    Staff(name: 'Flyer Handout Person', cost: 75, tapsPerSecond: 0.1);
+    Staff(name: 'Flyer Handout Person', cost: 375, tapsPerSecond: 0.2);
 const Staff _waitressOnSkates =
-    Staff(name: 'Waitress on Skates', cost: 400, tapsPerSecond: 1.5);
+    Staff(name: 'Waitress on Skates', cost: 2000, tapsPerSecond: 3.0);
 const Staff _grumpyCook =
-    Staff(name: 'Grumpy but Efficient Cook', cost: 800, tapsPerSecond: 3.0);
+    Staff(name: 'Grumpy but Efficient Cook', cost: 4000, tapsPerSecond: 6.0);
 const Staff _shiftManager =
-    Staff(name: 'Shift Manager', cost: 2000, tapsPerSecond: 5.0);
+    Staff(name: 'Shift Manager', cost: 10000, tapsPerSecond: 10.0);
 const Staff _marketingIntern =
-    Staff(name: 'Marketing Intern', cost: 3500, tapsPerSecond: 1.0);
+    Staff(name: 'Marketing Intern', cost: 17500, tapsPerSecond: 2.0);
 const Staff _corporateConsultant =
-    Staff(name: 'Corporate Consultant', cost: 5000, tapsPerSecond: 6.0);
+    Staff(name: 'Corporate Consultant', cost: 25000, tapsPerSecond: 12.0);
 const Staff _brandAmbassador =
-    Staff(name: 'Brand Ambassador', cost: 7500, tapsPerSecond: 8.0);
+    Staff(name: 'Brand Ambassador', cost: 37500, tapsPerSecond: 16.0);
 const Staff _alienSousChef =
-    Staff(name: 'Alien Sous Chef', cost: 15000, tapsPerSecond: 12.0);
+    Staff(name: 'Alien Sous Chef', cost: 75000, tapsPerSecond: 24.0);
 const Staff _robotServer =
-    Staff(name: 'Robot Server', cost: 25000, tapsPerSecond: 15.0);
+    Staff(name: 'Robot Server', cost: 125000, tapsPerSecond: 30.0);
 const Staff _aiHost =
-    Staff(name: 'AI Host', cost: 40000, tapsPerSecond: 20.0);
+    Staff(name: 'AI Host', cost: 200000, tapsPerSecond: 40.0);
 const Staff _quantumCook =
-    Staff(name: 'Quantum Cook', cost: 60000, tapsPerSecond: 25.0);
+    Staff(name: 'Quantum Cook', cost: 300000, tapsPerSecond: 50.0);
 const Staff _chronoChef =
-    Staff(name: 'Chrono Chef', cost: 100000, tapsPerSecond: 30.0);
+    Staff(name: 'Chrono Chef', cost: 500000, tapsPerSecond: 60.0);
 const Staff _timeWaiter =
-    Staff(name: 'Time Waiter', cost: 150000, tapsPerSecond: 35.0);
+    Staff(name: 'Time Waiter', cost: 750000, tapsPerSecond: 70.0);
 const Staff _multiverseManager =
-    Staff(name: 'Multiverse Manager', cost: 250000, tapsPerSecond: 45.0);
+    Staff(name: 'Multiverse Manager', cost: 1250000, tapsPerSecond: 90.0);
 const Staff _realityServer =
-    Staff(name: 'Reality Server', cost: 400000, tapsPerSecond: 60.0);
+    Staff(name: 'Reality Server', cost: 2000000, tapsPerSecond: 120.0);
 
 /// Lookup for all staff by type regardless of tier.
 const Map<StaffType, Staff> staffOptions = {

--- a/lib/models/upgrade.dart
+++ b/lib/models/upgrade.dart
@@ -20,60 +20,60 @@ class Upgrade {
 /// create fresh [Upgrade] instances based on these templates so that ownership
 /// counts remain local to the player's state.
 final Map<int, List<Upgrade>> upgradesByTier = {
-  0: [
-    Upgrade(name: 'Better Grill', cost: 30, effect: 1),
-    Upgrade(name: 'Heat Lamps', cost: 75, effect: 1),
-    Upgrade(name: 'Bigger Condiment Station', cost: 150, effect: 2),
+ 0: [
+    Upgrade(name: 'Better Grill', cost: 150, effect: 2),
+    Upgrade(name: 'Heat Lamps', cost: 375, effect: 2),
+    Upgrade(name: 'Bigger Condiment Station', cost: 750, effect: 4),
   ],
   1: [
-    Upgrade(name: 'Jukebox', cost: 300, effect: 2),
-    Upgrade(name: 'Milkshake Machine', cost: 600, effect: 3),
-    Upgrade(name: 'Comfier Booths', cost: 1200, effect: 2),
+    Upgrade(name: 'Jukebox', cost: 1500, effect: 4),
+    Upgrade(name: 'Milkshake Machine', cost: 3000, effect: 6),
+    Upgrade(name: 'Comfier Booths', cost: 6000, effect: 4),
   ],
   2: [
-    Upgrade(name: 'Corporate Training', cost: 2500, effect: 3),
-    Upgrade(name: 'Supply Chain Logistics', cost: 5000, effect: 5),
-    Upgrade(name: 'Automated Drive-Thru', cost: 10000, effect: 8),
+    Upgrade(name: 'Corporate Training', cost: 12500, effect: 6),
+    Upgrade(name: 'Supply Chain Logistics', cost: 25000, effect: 10),
+    Upgrade(name: 'Automated Drive-Thru', cost: 50000, effect: 16),
   ],
   3: [
-    Upgrade(name: 'Global Advertising', cost: 20000, effect: 10),
-    Upgrade(name: 'Celebrity Chef Partnership', cost: 40000, effect: 12),
-    Upgrade(name: 'International Logistics', cost: 80000, effect: 15),
+    Upgrade(name: 'Global Advertising', cost: 100000, effect: 20),
+    Upgrade(name: 'Celebrity Chef Partnership', cost: 200000, effect: 24),
+    Upgrade(name: 'International Logistics', cost: 400000, effect: 30),
   ],
   4: [
-    Upgrade(name: 'Zero-G Kitchens', cost: 150000, effect: 20),
-    Upgrade(name: 'Alien Ingredient Contracts', cost: 300000, effect: 30),
-    Upgrade(name: 'Hyperdrive Delivery', cost: 600000, effect: 45),
+    Upgrade(name: 'Zero-G Kitchens', cost: 750000, effect: 40),
+    Upgrade(name: 'Alien Ingredient Contracts', cost: 1500000, effect: 60),
+    Upgrade(name: 'Hyperdrive Delivery', cost: 3000000, effect: 90),
   ],
   5: [
-    Upgrade(name: 'Singularity Stove', cost: 1000000, effect: 60),
-    Upgrade(name: 'Quantum Spice Rack', cost: 1500000, effect: 80),
-    Upgrade(name: 'AI Gourmet Designer', cost: 2000000, effect: 100),
+    Upgrade(name: 'Singularity Stove', cost: 5000000, effect: 120),
+    Upgrade(name: 'Quantum Spice Rack', cost: 7500000, effect: 160),
+    Upgrade(name: 'AI Gourmet Designer', cost: 10000000, effect: 200),
   ],
   6: [
-    Upgrade(name: 'Time Dilation Oven', cost: 2500000, effect: 120),
-    Upgrade(name: 'Chrono Shift Staff', cost: 3500000, effect: 160),
-    Upgrade(name: 'Paradox Inventory', cost: 5000000, effect: 200),
+    Upgrade(name: 'Time Dilation Oven', cost: 12500000, effect: 240),
+    Upgrade(name: 'Chrono Shift Staff', cost: 17500000, effect: 320),
+    Upgrade(name: 'Paradox Inventory', cost: 25000000, effect: 400),
   ],
   7: [
-    Upgrade(name: 'Dimensional Dining Room', cost: 8000000, effect: 250),
-    Upgrade(name: 'Infinite Menu Generator', cost: 10000000, effect: 300),
-    Upgrade(name: 'Reality Distortion Service', cost: 12000000, effect: 350),
+    Upgrade(name: 'Dimensional Dining Room', cost: 40000000, effect: 500),
+    Upgrade(name: 'Infinite Menu Generator', cost: 50000000, effect: 600),
+    Upgrade(name: 'Reality Distortion Service', cost: 60000000, effect: 700),
   ],
   8: [
-    Upgrade(name: 'Quantum Entanglement Oven', cost: 14000000, effect: 400),
-    Upgrade(name: 'Dark Matter Marinade', cost: 18000000, effect: 450),
-    Upgrade(name: 'Teleport Delivery', cost: 22000000, effect: 500),
+    Upgrade(name: 'Quantum Entanglement Oven', cost: 70000000, effect: 800),
+    Upgrade(name: 'Dark Matter Marinade', cost: 90000000, effect: 900),
+    Upgrade(name: 'Teleport Delivery', cost: 110000000, effect: 1000),
   ],
   9: [
-    Upgrade(name: 'Cosmic Catering', cost: 28000000, effect: 550),
-    Upgrade(name: 'Galaxy Infusion Lab', cost: 34000000, effect: 600),
-    Upgrade(name: 'Gravity-Free Dining', cost: 40000000, effect: 650),
+    Upgrade(name: 'Cosmic Catering', cost: 140000000, effect: 1100),
+    Upgrade(name: 'Galaxy Infusion Lab', cost: 170000000, effect: 1200),
+    Upgrade(name: 'Gravity-Free Dining', cost: 200000000, effect: 1300),
   ],
- 10: [
-    Upgrade(name: 'Reality Rewrite Kitchen', cost: 50000000, effect: 700),
-    Upgrade(name: 'Omniversal Reservations', cost: 60000000, effect: 800),
-    Upgrade(name: 'Existence Flavour Enhancer', cost: 75000000, effect: 900),
+  10: [
+    Upgrade(name: 'Reality Rewrite Kitchen', cost: 250000000, effect: 1400),
+    Upgrade(name: 'Omniversal Reservations', cost: 300000000, effect: 1600),
+    Upgrade(name: 'Existence Flavour Enhancer', cost: 375000000, effect: 1800),
   ],
 };
 

--- a/test/franchise_test.dart
+++ b/test/franchise_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:taptapchef/controllers/game_controller.dart';
+import 'package:taptapchef/models/game_state.dart';
+import 'package:taptapchef/models/staff.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('franchise resets progress and grants artifact', () async {
+    SharedPreferences.setMockInitialValues({});
+    final controller = GameController();
+    controller.game.milestoneIndex = GameState.milestones.length - 1;
+    controller.coins = 100;
+    controller.perTap = 10;
+    controller.hiredStaff[StaffType.tacoFlipper] = 2;
+    controller.upgrades.first.owned = 1;
+
+    await controller.franchise();
+
+    expect(controller.coins, 0);
+    expect(controller.perTap, 1);
+    expect(controller.hiredStaff, isEmpty);
+    expect(controller.upgrades.every((u) => u.owned == 0), isTrue);
+    expect(controller.game.milestoneIndex, 0);
+    expect(controller.game.ownedArtifactIds.length, 1);
+  });
+}

--- a/test/game_state_test.dart
+++ b/test/game_state_test.dart
@@ -16,10 +16,10 @@ void main() {
     game.franchiseTokens = 1;
 
     final baseGoal = GameState.baseMilestoneGoals.first;
-    expect(game.milestoneGoalAt(0), (baseGoal * 0.02).ceil());
+    expect(game.milestoneGoalAt(0), (baseGoal * 0.5).ceil());
 
     final lastBaseGoal = GameState.baseMilestoneGoals.last;
     expect(game.milestoneGoalAt(GameState.baseMilestoneGoals.length - 1),
-        (lastBaseGoal * 0.02).ceil());
+        (lastBaseGoal * 0.5).ceil());
   });
 }


### PR DESCRIPTION
## Summary
- overhaul upgrade and staff costs and effects for harder progression
- expand milestone goals and reduce post-franchise scaling
- add franchise method to reset player stats and award an artifact
- call new franchise logic from the UI
- adjust test for new milestone scaling and add a franchise test

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ec3ec2548321bc7e36fc53da6065