### PR TITLE
UI overhaul with bottom navigation

### DIFF
--- a/lib/screens/boosts_screen.dart
+++ b/lib/screens/boosts_screen.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import '../widgets/artifact_pantry.dart';
+import '../controllers/game_controller.dart';
+
+/// Screen for ad rewards and artifact management.
+class BoostsScreen extends StatefulWidget {
+  final GameController controller;
+  final Future<bool> Function() watchAd;
+
+  const BoostsScreen({
+    super.key,
+    required this.controller,
+    required this.watchAd,
+  });
+
+  @override
+  State<BoostsScreen> createState() => _BoostsScreenState();
+}
+
+class _BoostsScreenState extends State<BoostsScreen>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _rewardFiveMin() async {
+    final ok = await widget.watchAd();
+    if (ok) widget.controller.startAdBoost();
+  }
+
+  Future<void> _rewardCoins() async {
+    final ok = await widget.watchAd();
+    if (ok) widget.controller.addCoins(100);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        TabBar(
+          controller: _tabController,
+          tabs: const [
+            Tab(text: 'Rewards'),
+            Tab(text: 'The Pantry'),
+          ],
+        ),
+        Expanded(
+          child: TabBarView(
+            controller: _tabController,
+            children: [
+              ListView(
+                children: [
+                  ListTile(
+                    leading: const Icon(Icons.timer),
+                    title: const Text('Double earnings for 5 minutes'),
+                    onTap: _rewardFiveMin,
+                  ),
+                  ListTile(
+                    leading: const Icon(Icons.attach_money),
+                    title: const Text('Get 100 coins'),
+                    onTap: _rewardCoins,
+                  ),
+                  ListTile(
+                    leading: const Icon(Icons.mood),
+                    title: const Text('Rip a Joint'),
+                    onTap: widget.controller.startRipMode,
+                  ),
+                ],
+              ),
+              ArtifactPantry(game: widget.controller.game),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/screens/kitchen_screen.dart
+++ b/lib/screens/kitchen_screen.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import "../models/game_state.dart";
+import "../constants/panels.dart";
+import '../controllers/game_controller.dart';
+import '../models/staff.dart';
+import '../models/upgrade.dart';
+import '../util/format.dart';
+import '../widgets/upgrade_panel.dart';
+import '../widgets/staff_panel.dart';
+
+/// Main gameplay screen for tapping and viewing progress.
+class KitchenScreen extends StatelessWidget {
+  final GameController controller;
+  final void Function(Upgrade, int) purchaseUpgrade;
+  final void Function(StaffType, int) hireStaff;
+  final VoidCallback onAdReward;
+  final VoidCallback onPantry;
+  final VoidCallback onSettings;
+
+  const KitchenScreen({
+    super.key,
+    required this.controller,
+    required this.hireStaff,
+    required this.purchaseUpgrade,
+    required this.onAdReward,
+    required this.onPantry,
+    required this.onSettings,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final bool finalStage = controller.game.atFinalMilestone;
+    final int goal = finalStage ? 0 : controller.game.currentMilestoneGoal;
+    final double progress =
+        finalStage ? 1 : controller.game.mealsServed / goal;
+    final String nextName = finalStage
+        ? 'Completed'
+        : GameState.milestones[controller.game.milestoneIndex + 1];
+    final availableStaff =
+        staffByTier[controller.game.milestoneIndex] ?? {};
+
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Row(
+                  children: [
+                    const Icon(Icons.attach_money, size: 20),
+                    const SizedBox(width: 4),
+                    Text(formatNumber(controller.coins)),
+                  ],
+                ),
+                Row(
+                  children: [
+                    const Icon(Icons.business, size: 20),
+                    const SizedBox(width: 4),
+                    Text(formatNumber(controller.game.franchiseTokens)),
+                  ],
+                ),
+                IconButton(
+                  icon: const Icon(Icons.settings),
+                  onPressed: onSettings,
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text('Current Location: ${controller.game.currentLocation.name}',
+                style:
+                    const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+            const SizedBox(height: 4),
+            LinearProgressIndicator(value: progress),
+            Text(finalStage
+                ? 'Final milestone reached'
+                : '${(progress * 100).toStringAsFixed(0)}% to $nextName'),
+            const SizedBox(height: 16),
+            Text('Meals Served: ${formatNumber(controller.game.mealsServed)}'),
+            Text('Income per Tap: ${controller.perTap}'),
+            const SizedBox(height: 16),
+            Center(
+              child: ElevatedButton(
+                onPressed: controller.cook,
+                child: const Text('Cook!'),
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text('Combo: ${controller.combo}  x${controller.currentMultiplier}'),
+            LinearProgressIndicator(value: controller.combo / GameController.comboMax),
+            if (controller.adBoostActive)
+              Text(
+                  'Ad boost: ${(controller.adBoostSeconds ~/ 60).toString().padLeft(2, '0')}:${(controller.adBoostSeconds % 60).toString().padLeft(2, '0')}'),
+            const SizedBox(height: 16),
+            UpgradePanel(
+              upgrades: controller.upgrades,
+              currency: controller.coins,
+              onPurchase: purchaseUpgrade,
+              title: upgradePanelTitles[controller.game.milestoneIndex],
+            ),
+            const SizedBox(height: 16),
+            StaffPanel(
+              staff: availableStaff,
+              hired: controller.hiredStaff,
+              coins: controller.coins,
+              onHire: hireStaff,
+              title: hirePanelTitles[controller.game.milestoneIndex],
+            ),
+            ElevatedButton(
+              onPressed: onAdReward,
+              child: const Text('Watch Ad for Rewards'),
+            ),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: onPantry,
+              child: const Text('The Pantry'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/prestige_screen.dart
+++ b/lib/screens/prestige_screen.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import '../controllers/game_controller.dart';
+import '../widgets/franchise_hq.dart';
+
+/// Screen for managing prestige actions and upgrades.
+class PrestigeScreen extends StatelessWidget {
+  final GameController controller;
+  final Future<void> Function() onConfirmDeal;
+
+  const PrestigeScreen({
+    super.key,
+    required this.controller,
+    required this.onConfirmDeal,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final canDeal = controller.game.atFinalMilestone;
+    final tokens = 1 + (controller.game.mealsServed ~/ 1000);
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(Icons.business),
+              const SizedBox(width: 4),
+              Text('Tokens: ${controller.game.franchiseTokens}')
+            ],
+          ),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: canDeal ? onConfirmDeal : null,
+            child: Text(
+              canDeal
+                  ? 'Sign Deal for $tokens Tokens'
+                  : 'Reach Final Milestone to Unlock',
+            ),
+          ),
+          const Divider(),
+          FranchiseHQ(
+            game: controller.game,
+            onPurchase: (id) {
+              controller.game.purchasePrestigeUpgrade(id);
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/upgrades_screen.dart
+++ b/lib/screens/upgrades_screen.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import '../widgets/upgrade_panel.dart';
+import '../widgets/staff_panel.dart';
+import '../controllers/game_controller.dart';
+import '../constants/panels.dart';
+import '../models/staff.dart';
+import "../models/upgrade.dart";
+
+/// Screen containing upgrade and staff purchase panels under two tabs.
+class UpgradesScreen extends StatefulWidget {
+  final GameController controller;
+  final void Function(Upgrade upgrade, int qty) onPurchase;
+  final void Function(StaffType type, int qty) onHire;
+
+  const UpgradesScreen({
+    super.key,
+    required this.controller,
+    required this.onPurchase,
+    required this.onHire,
+  });
+
+  @override
+  State<UpgradesScreen> createState() => _UpgradesScreenState();
+}
+
+class _UpgradesScreenState extends State<UpgradesScreen>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final availableStaff =
+        staffByTier[widget.controller.game.milestoneIndex] ?? {};
+    return Column(
+      children: [
+        TabBar(
+          controller: _tabController,
+          tabs: const [
+            Tab(text: 'Kitchen'),
+            Tab(text: 'Staff'),
+          ],
+        ),
+        Expanded(
+          child: TabBarView(
+            controller: _tabController,
+            children: [
+              SingleChildScrollView(
+                padding: const EdgeInsets.all(16),
+                child: UpgradePanel(
+                  upgrades: widget.controller.upgrades,
+                  currency: widget.controller.coins,
+                  onPurchase: widget.onPurchase,
+                  title: upgradePanelTitles[
+                      widget.controller.game.milestoneIndex],
+                ),
+              ),
+              SingleChildScrollView(
+                padding: const EdgeInsets.all(16),
+                child: StaffPanel(
+                  staff: availableStaff,
+                  hired: widget.controller.hiredStaff,
+                  coins: widget.controller.coins,
+                  onHire: widget.onHire,
+                  title: hirePanelTitles[
+                      widget.controller.game.milestoneIndex],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add bottom nav with Kitchen, Upgrades, Prestige and Boosts tabs
- move gameplay components to new screens
- include a simple settings modal

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ed75f7e083219debd77e902f9d41