### PR TITLE
UI tweaks and simplified purchase panels

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -357,6 +357,8 @@ class _CounterPageState extends ConsumerState<CounterPage>
         bottomNavigationBar: BottomNavigationBar(
           currentIndex: _navIndex,
           onTap: (i) => setState(() => _navIndex = i),
+          selectedItemColor: Colors.black,
+          unselectedItemColor: Colors.black,
           items: const [
             BottomNavigationBarItem(
                 icon: Icon(Icons.local_fire_department), label: "Kitchen"),

--- a/lib/screens/kitchen_screen.dart
+++ b/lib/screens/kitchen_screen.dart
@@ -39,47 +39,52 @@ class KitchenScreen extends StatelessWidget {
     final availableStaff =
         staffByTier[controller.game.milestoneIndex] ?? {};
 
-    return Padding(
-      padding: const EdgeInsets.all(16),
-      child: SingleChildScrollView(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+    return Column(
+      children: [
+        Container(
+          padding: const EdgeInsets.all(16),
+          color: Theme.of(context).scaffoldBackgroundColor,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Row(
+                children: [
+                  const Icon(Icons.attach_money, size: 20),
+                  const SizedBox(width: 4),
+                  Text(formatNumber(controller.coins)),
+                ],
+              ),
+              Row(
+                children: [
+                  const Icon(Icons.business, size: 20),
+                  const SizedBox(width: 4),
+                  Text(formatNumber(controller.game.franchiseTokens)),
+                ],
+              ),
+              IconButton(
+                icon: const Icon(Icons.settings),
+                onPressed: onSettings,
+              ),
+            ],
+          ),
+        ),
+        Expanded(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Row(
-                  children: [
-                    const Icon(Icons.attach_money, size: 20),
-                    const SizedBox(width: 4),
-                    Text(formatNumber(controller.coins)),
-                  ],
-                ),
-                Row(
-                  children: [
-                    const Icon(Icons.business, size: 20),
-                    const SizedBox(width: 4),
-                    Text(formatNumber(controller.game.franchiseTokens)),
-                  ],
-                ),
-                IconButton(
-                  icon: const Icon(Icons.settings),
-                  onPressed: onSettings,
-                ),
-              ],
-            ),
-            const SizedBox(height: 8),
-            Text('Current Location: ${controller.game.currentLocation.name}',
-                style:
-                    const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
-            const SizedBox(height: 4),
-            LinearProgressIndicator(value: progress),
-            Text(finalStage
-                ? 'Final milestone reached'
-                : '${(progress * 100).toStringAsFixed(0)}% to $nextName'),
-            const SizedBox(height: 16),
-            Text('Meals Served: ${formatNumber(controller.game.mealsServed)}'),
-            Text('Income per Tap: ${controller.perTap}'),
+                Text('Current Location: ${controller.game.currentLocation.name}',
+                    style: const TextStyle(
+                        fontSize: 20, fontWeight: FontWeight.bold)),
+                const SizedBox(height: 4),
+                LinearProgressIndicator(value: progress),
+                Text(finalStage
+                    ? 'Final milestone reached'
+                    : '${(progress * 100).toStringAsFixed(0)}% to $nextName'),
+                const SizedBox(height: 16),
+                Text('Meals Served: ${formatNumber(controller.game.mealsServed)}'),
+                Text('Income per Tap: ${controller.perTap}'),
             const SizedBox(height: 16),
             Center(
               child: ElevatedButton(

--- a/lib/widgets/staff_panel.dart
+++ b/lib/widgets/staff_panel.dart
@@ -33,7 +33,6 @@ class StaffPanel extends StatelessWidget {
           final bool affordable = coins >= s.cost;
           final bool affordable10 = coins >= s.cost * 10;
           final bool affordable100 = coins >= s.cost * 100;
-          final int maxAffordable = coins ~/ s.cost;
           return Card(
             margin: const EdgeInsets.symmetric(vertical: 4),
             child: Padding(
@@ -83,13 +82,6 @@ class StaffPanel extends StatelessWidget {
                         onPressed:
                             affordable100 ? () => onHire(type, 100) : null,
                         child: const Text('100'),
-                      ),
-                      const SizedBox(width: 4),
-                      ElevatedButton(
-                        onPressed: maxAffordable > 0
-                            ? () => onHire(type, maxAffordable)
-                            : null,
-                        child: const Text('MAX'),
                       ),
                     ],
                   ),

--- a/lib/widgets/upgrade_panel.dart
+++ b/lib/widgets/upgrade_panel.dart
@@ -27,7 +27,6 @@ class UpgradePanel extends StatelessWidget {
         final bool affordable = currency >= u.cost;
         final bool affordable10 = currency >= u.cost * 10;
         final bool affordable100 = currency >= u.cost * 100;
-        final int maxAffordable = currency ~/ u.cost;
         return Card(
           margin: const EdgeInsets.symmetric(vertical: 4),
           child: Padding(
@@ -77,13 +76,6 @@ class UpgradePanel extends StatelessWidget {
                       onPressed:
                           affordable100 ? () => onPurchase(u, 100) : null,
                       child: const Text('100'),
-                    ),
-                    const SizedBox(width: 4),
-                    ElevatedButton(
-                      onPressed: maxAffordable > 0
-                          ? () => onPurchase(u, maxAffordable)
-                          : null,
-                      child: const Text('MAX'),
                     ),
                   ],
                 ),


### PR DESCRIPTION
## Summary
- keep info row fixed at the top of `KitchenScreen`
- drop the MAX purchase buttons from upgrade and staff panels
- make bottom navigation text and icons black

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68530a06c9288321a21b663c19ad7209