### PR TITLE
Highlight affordable upgrades

### DIFF
--- a/lib/controllers/game_controller.dart
+++ b/lib/controllers/game_controller.dart
@@ -55,6 +55,17 @@ class GameController extends ChangeNotifier {
 
   bool specialVisible = false;
 
+  bool get anyPurchasesAffordable {
+    if (upgrades.any((u) => coins >= u.cost)) {
+      return true;
+    }
+    final availableStaff = staffByTier[game.milestoneIndex] ?? {};
+    for (final s in availableStaff.values) {
+      if (coins >= s.cost) return true;
+    }
+    return false;
+  }
+
   Future<OfflineLoadResult> load() async {
     final result = await _storage.loadGame(idleMultiplier: 0.000833);
     final player = await _storage.loadPlayerData();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -359,14 +359,33 @@ class _CounterPageState extends ConsumerState<CounterPage>
           onTap: (i) => setState(() => _navIndex = i),
           selectedItemColor: Colors.black,
           unselectedItemColor: Colors.black,
-          items: const [
-            BottomNavigationBarItem(
+          items: [
+            const BottomNavigationBarItem(
                 icon: Icon(Icons.local_fire_department), label: "Kitchen"),
             BottomNavigationBarItem(
-                icon: Icon(Icons.arrow_upward), label: "Upgrades"),
-            BottomNavigationBarItem(
+              icon: Stack(
+                children: [
+                  const Icon(Icons.arrow_upward),
+                  if (controller.anyPurchasesAffordable)
+                    Positioned(
+                      right: 0,
+                      top: 0,
+                      child: Container(
+                        width: 8,
+                        height: 8,
+                        decoration: const BoxDecoration(
+                          color: Colors.red,
+                          shape: BoxShape.circle,
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+              label: "Upgrades",
+            ),
+            const BottomNavigationBarItem(
                 icon: Icon(Icons.star_border), label: "Prestige"),
-            BottomNavigationBarItem(
+            const BottomNavigationBarItem(
                 icon: Icon(Icons.rocket_launch), label: "Boosts"),
           ],
         ));

--- a/lib/widgets/staff_panel.dart
+++ b/lib/widgets/staff_panel.dart
@@ -33,8 +33,10 @@ class StaffPanel extends StatelessWidget {
           final bool affordable = coins >= s.cost;
           final bool affordable10 = coins >= s.cost * 10;
           final bool affordable100 = coins >= s.cost * 100;
+          final bool highlightCard = affordable10 || affordable100;
           return Card(
             margin: const EdgeInsets.symmetric(vertical: 4),
+            color: highlightCard ? Colors.green[50] : null,
             child: Padding(
               padding: const EdgeInsets.all(8),
               child: Column(
@@ -73,15 +75,21 @@ class StaffPanel extends StatelessWidget {
                         ),
                       ),
                       const SizedBox(width: 4),
-                      ElevatedButton(
-                        onPressed: affordable10 ? () => onHire(type, 10) : null,
-                        child: const Text('10'),
+                      Pulse(
+                        active: affordable10,
+                        child: ElevatedButton(
+                          onPressed: affordable10 ? () => onHire(type, 10) : null,
+                          child: const Text('10'),
+                        ),
                       ),
                       const SizedBox(width: 4),
-                      ElevatedButton(
-                        onPressed:
-                            affordable100 ? () => onHire(type, 100) : null,
-                        child: const Text('100'),
+                      Pulse(
+                        active: affordable100,
+                        child: ElevatedButton(
+                          onPressed:
+                              affordable100 ? () => onHire(type, 100) : null,
+                          child: const Text('100'),
+                        ),
                       ),
                     ],
                   ),

--- a/lib/widgets/upgrade_panel.dart
+++ b/lib/widgets/upgrade_panel.dart
@@ -27,8 +27,10 @@ class UpgradePanel extends StatelessWidget {
         final bool affordable = currency >= u.cost;
         final bool affordable10 = currency >= u.cost * 10;
         final bool affordable100 = currency >= u.cost * 100;
+        final bool highlightCard = affordable10 || affordable100;
         return Card(
           margin: const EdgeInsets.symmetric(vertical: 4),
+          color: highlightCard ? Colors.green[50] : null,
           child: Padding(
             padding: const EdgeInsets.all(8.0),
             child: Column(
@@ -67,15 +69,21 @@ class UpgradePanel extends StatelessWidget {
                       ),
                     ),
                     const SizedBox(width: 4),
-                    ElevatedButton(
-                      onPressed: affordable10 ? () => onPurchase(u, 10) : null,
-                      child: const Text('10'),
+                    Pulse(
+                      active: affordable10,
+                      child: ElevatedButton(
+                        onPressed: affordable10 ? () => onPurchase(u, 10) : null,
+                        child: const Text('10'),
+                      ),
                     ),
                     const SizedBox(width: 4),
-                    ElevatedButton(
-                      onPressed:
-                          affordable100 ? () => onPurchase(u, 100) : null,
-                      child: const Text('100'),
+                    Pulse(
+                      active: affordable100,
+                      child: ElevatedButton(
+                        onPressed:
+                            affordable100 ? () => onPurchase(u, 100) : null,
+                        child: const Text('100'),
+                      ),
                     ),
                   ],
                 ),


### PR DESCRIPTION
## Summary
- pulse 10/100 upgrade buttons and tint the card when larger purchases are affordable
- highlight staff cards and buttons the same way
- show a red badge on the Upgrades tab when anything is affordable
- expose `anyPurchasesAffordable` in `GameController`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531858b83c8321bafd094061547b2f