### PR TITLE
Improve clarity of top bar and progress UI

### DIFF
--- a/lib/controllers/game_controller.dart
+++ b/lib/controllers/game_controller.dart
@@ -36,6 +36,12 @@ class GameController extends ChangeNotifier {
   int get lastMilestoneIndex => _lastMilestoneIndex;
   double currentTPS = 0;
 
+  /// Current passive income per second in coins.
+  double get idleIncomePerSecond {
+    final tapValue = effectService.calculateTapValue(perTap.toDouble());
+    return currentTPS * tapValue;
+  }
+
   bool ripMode = false;
   Color ripColor = Colors.transparent;
   double ripRotation = 0;

--- a/lib/screens/kitchen_screen.dart
+++ b/lib/screens/kitchen_screen.dart
@@ -46,17 +46,30 @@ class KitchenScreen extends StatelessWidget {
           color: Theme.of(context).scaffoldBackgroundColor,
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Row(
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  const Icon(Icons.attach_money, size: 20),
-                  const SizedBox(width: 4),
-                  Text(formatNumber(controller.coins)),
+                  Row(
+                    children: [
+                      const Tooltip(
+                          message: 'Cash',
+                          child: Icon(Icons.attach_money, size: 20)),
+                      const SizedBox(width: 4),
+                      Text(formatNumber(controller.coins)),
+                    ],
+                  ),
+                  Text(
+                    'Idle: ${formatNumber(controller.idleIncomePerSecond.round())}/sec',
+                    style: const TextStyle(fontSize: 10),
+                  ),
                 ],
               ),
               Row(
                 children: [
-                  const Icon(Icons.business, size: 20),
+                  const Tooltip(
+                      message: 'Tokens', child: Icon(Icons.token, size: 20)),
                   const SizedBox(width: 4),
                   Text(formatNumber(controller.game.franchiseTokens)),
                 ],
@@ -81,7 +94,7 @@ class KitchenScreen extends StatelessWidget {
                 LinearProgressIndicator(value: progress),
                 Text(finalStage
                     ? 'Final milestone reached'
-                    : '${(progress * 100).toStringAsFixed(0)}% to $nextName'),
+                    : '${formatNumber(controller.game.mealsServed)}/${formatNumber(goal)} meals - ${(progress * 100).toStringAsFixed(0)}% to $nextName'),
                 const SizedBox(height: 16),
                 Text('Meals Served: ${formatNumber(controller.game.mealsServed)}'),
                 Text('Income per Tap: ${controller.perTap}'),


### PR DESCRIPTION
## Summary
- add getter for idle income per second
- show idle income in kitchen screen
- replace token icon and add tooltips
- show numeric progress to next milestone

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685319b14f8c832191968a0f53380f8c