### PR TITLE
Enhance prestige info and add progression sheet

### DIFF
--- a/lib/screens/prestige_screen.dart
+++ b/lib/screens/prestige_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../controllers/game_controller.dart';
 import '../widgets/franchise_hq.dart';
+import '../widgets/progression_sheet.dart';
 
 /// Screen for managing prestige actions and upgrades.
 class PrestigeScreen extends StatelessWidget {
@@ -22,12 +23,38 @@ class PrestigeScreen extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          const Text(
+            'Prestige resets your restaurant in exchange for Franchise Tokens, which unlock permanent upgrades.',
+          ),
+          const SizedBox(height: 16),
           Row(
             children: [
               const Icon(Icons.business),
               const SizedBox(width: 4),
-              Text('Tokens: ${controller.game.franchiseTokens}')
+              Text('Tokens: ${controller.game.franchiseTokens}'),
+              const SizedBox(width: 4),
+              const Tooltip(
+                message:
+                    'Franchise Tokens unlock permanent upgrades that persist after prestiging.',
+                child: Icon(Icons.info_outline, size: 16),
+              ),
             ],
+          ),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: () {
+              showModalBottomSheet(
+                context: context,
+                builder: (_) => SizedBox(
+                  height: 400,
+                  child: ProgressionSheet(
+                    currentTier: controller.game.milestoneIndex,
+                    currentProgress: controller.game.mealsServed,
+                  ),
+                ),
+              );
+            },
+            child: const Text('View Progression'),
           ),
           const SizedBox(height: 16),
           ElevatedButton(


### PR DESCRIPTION
## Summary
- explain prestige and tokens directly in `PrestigeScreen`
- add tooltip and info button for Franchise Tokens
- allow viewing of all progression tiers from the Prestige screen

## Testing
- `flutter test` *(fails: dart-sdk missing)*

------
https://chatgpt.com/codex/tasks/task_e_685378f8ab308321bf517cfb0249626b