### PR TITLE
Add milestone background support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Inspired by **Egg, Inc.** and **Universal Paperclips**, Tap Tap Chef balances a 
 - Light 3D or illustrated sprites with soft color palettes
 - Minimalist UI with Egg Inc–style bounce and clarity
 - Expressive, humorous character animations (chefs, customers, aliens)
+- Milestone locations use unique background art to show your expansion
 
 ---
 

--- a/lib/constants/milestones.dart
+++ b/lib/constants/milestones.dart
@@ -74,3 +74,18 @@ const List<String> milestoneDialogues = [
   "Cosmic beings book tables centuries in advance.",
   "You serve reality itself. Taste is subjective.",
 ];
+
+/// Placeholder asset paths for milestone background images.
+const List<String> milestoneBackgrounds = [
+  'assets/images/bg_street.png',
+  'assets/images/bg_diner.png',
+  'assets/images/bg_chain.png',
+  'assets/images/bg_corporate.png',
+  'assets/images/bg_space.png',
+  'assets/images/bg_endgame.png',
+  'assets/images/bg_time.png',
+  'assets/images/bg_multiverse.png',
+  'assets/images/bg_quantum.png',
+  'assets/images/bg_cosmic.png',
+  'assets/images/bg_omniversal.png',
+];

--- a/lib/models/game_state.dart
+++ b/lib/models/game_state.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'prestige.dart';
 import 'franchise_location.dart';
 import 'prestige_upgrade.dart';
+import '../constants/milestones.dart';
 
 class GameState extends ChangeNotifier {
   int mealsServed;
@@ -20,6 +21,10 @@ class GameState extends ChangeNotifier {
   FranchiseLocation get currentLocation => franchiseLocationSets[
           locationSetIndex % franchiseLocationSets.length]
       [locationTierIndex];
+
+  /// Background image associated with the current milestone.
+  String get currentBackground =>
+      milestoneBackgrounds[milestoneIndex];
 
   GameState({this.mealsServed = 0, this.milestoneIndex = 0, Prestige? prestige})
       : prestige = prestige ?? Prestige();

--- a/lib/screens/kitchen_screen.dart
+++ b/lib/screens/kitchen_screen.dart
@@ -39,12 +39,25 @@ class KitchenScreen extends StatelessWidget {
     final availableStaff =
         staffByTier[controller.game.milestoneIndex] ?? {};
 
-    return Column(
+    return Stack(
       children: [
-        Container(
-          padding: const EdgeInsets.all(16),
-          color: Theme.of(context).scaffoldBackgroundColor,
-          child: Row(
+        Positioned.fill(
+          child: AnimatedSwitcher(
+            duration: const Duration(milliseconds: 500),
+            child: Image.asset(
+              controller.game.currentBackground,
+              key: ValueKey(controller.game.currentBackground),
+              fit: BoxFit.cover,
+              errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+            ),
+          ),
+        ),
+        Column(
+          children: [
+            Container(
+              padding: const EdgeInsets.all(16),
+              color: Theme.of(context).scaffoldBackgroundColor,
+              child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -138,6 +151,7 @@ class KitchenScreen extends StatelessWidget {
           ],
         ),
       ),
-    );
+    ],
+  );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,8 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+  assets:
+    - assets/images/
 
 flutter_icons:
   android: true


### PR DESCRIPTION
## Summary
- add assets directory and configure flutter to include it
- define placeholder background assets for each milestone
- expose current background on GameState
- show milestone background in `KitchenScreen` with fade transition
- mention backgrounds in README

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685380e33974832183e386b1390e8c48