### PR TITLE
Remove unused EffectEngine field

### DIFF
--- a/lib/controllers/game_controller.dart
+++ b/lib/controllers/game_controller.dart
@@ -5,20 +5,17 @@ import '../models/game_state.dart';
 import '../models/staff.dart';
 import '../models/upgrade.dart';
 import '../services/storage.dart';
-import 'effect_engine.dart';
 import '../models/artifact.dart';
 import '../services/effect_service.dart';
 
 class GameController extends ChangeNotifier {
   final GameState game;
   final StorageService _storage;
-  late final EffectEngine effects;
   late final EffectService effectService;
 
   GameController({GameState? state, StorageService? storage})
       : game = state ?? GameState(),
         _storage = storage ?? StorageService() {
-    effects = EffectEngine(game);
     effectService = EffectService(game);
     upgrades = upgradesForTier(game.milestoneIndex);
   }


### PR DESCRIPTION
## Summary
- clean up dead code by removing the `EffectEngine` import and field from `GameController`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68539c9e3ff48321b76ad43b384e1b0f