### PR TITLE
Fix safe area issues for screens

### DIFF
--- a/lib/screens/boosts_screen.dart
+++ b/lib/screens/boosts_screen.dart
@@ -46,8 +46,9 @@ class _BoostsScreenState extends State<BoostsScreen>
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
+    return SafeArea(
+      child: Column(
+        children: [
         TabBar(
           controller: _tabController,
           tabs: const [
@@ -77,6 +78,6 @@ class _BoostsScreenState extends State<BoostsScreen>
           ),
         ),
       ],
-    );
+    ));
   }
 }

--- a/lib/screens/kitchen_screen.dart
+++ b/lib/screens/kitchen_screen.dart
@@ -53,12 +53,13 @@ class KitchenScreen extends StatelessWidget {
             ),
           ),
         ),
-        Column(
-          children: [
-            Container(
-              padding: const EdgeInsets.all(16),
-              color: Theme.of(context).scaffoldBackgroundColor,
-              child: Row(
+        SafeArea(
+          child: Column(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(16),
+                color: Theme.of(context).scaffoldBackgroundColor,
+                child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -92,15 +93,15 @@ class KitchenScreen extends StatelessWidget {
                 icon: const Icon(Icons.settings),
                 onPressed: onSettings,
               ),
-            ],
-          ),
-        ),
-        Expanded(
-          child: SingleChildScrollView(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
+                ],
+              ),
+            ),
+            Expanded(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
                 Text('Current Location: ${controller.game.currentLocation.name}',
                     style: const TextStyle(
                         fontSize: 20, fontWeight: FontWeight.bold)),
@@ -152,7 +153,10 @@ class KitchenScreen extends StatelessWidget {
           ],
         ),
       ),
-        )],
-    )]);
+    ],
+  ),
+),
+      ],
+    );
   }
 }

--- a/lib/screens/prestige_screen.dart
+++ b/lib/screens/prestige_screen.dart
@@ -18,9 +18,10 @@ class PrestigeScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final canDeal = controller.game.atFinalMilestone;
     final tokens = 1 + (controller.game.mealsServed ~/ 1000);
-    return SingleChildScrollView(
-      padding: const EdgeInsets.all(16),
-      child: Column(
+    return SafeArea(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           const Text(
@@ -74,6 +75,6 @@ class PrestigeScreen extends StatelessWidget {
           ),
         ],
       ),
-    );
+    ));
   }
 }


### PR DESCRIPTION
## Summary
- add SafeArea wrapper to KitchenScreen to avoid notch obstruction
- wrap PrestigeScreen and BoostsScreen in SafeArea

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853a0c641548321973bcf4e0a12c127