### PR TITLE
Move upgrades and staff to separate management screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'providers/game_controller_provider.dart';
 import 'widgets/offline_earnings_dialog.dart';
 import 'widgets/ad_reward_sheet.dart';
 import 'screens/kitchen_screen.dart';
+import 'screens/management_screen.dart';
 import 'screens/prestige_screen.dart';
 import 'screens/boosts_screen.dart';
 import 'widgets/mini_game_dialog.dart';
@@ -199,10 +200,10 @@ class _CounterPageState extends ConsumerState<CounterPage>
     int? tab;
     if (index == 1) {
       message = 'New Feature Unlocked: Hire Staff!';
-      tab = 0; // Kitchen screen
+      tab = 1; // Management screen
     } else if (index == 3) {
       message = 'New Feature Unlocked: Prestige!';
-      tab = 1; // Prestige screen
+      tab = 2; // Prestige screen
     }
     if (message != null) {
       setState(() => _navIndex = tab!);
@@ -326,13 +327,18 @@ class _CounterPageState extends ConsumerState<CounterPage>
         return KitchenScreen(
           key: const ValueKey('kitchen'),
           controller: controller,
-          hireStaff: _hireStaff,
-          purchaseUpgrade: _purchase,
           onAdReward: _showAdRewardSheet,
           onSettings: _showSettings,
           frenzyOffset: _frenzyOffset,
         );
       case 1:
+        return ManagementScreen(
+          key: const ValueKey('manage'),
+          controller: controller,
+          purchaseUpgrade: _purchase,
+          hireStaff: _hireStaff,
+        );
+      case 2:
         return PrestigeScreen(
           key: const ValueKey('prestige'),
           controller: controller,
@@ -407,6 +413,8 @@ class _CounterPageState extends ConsumerState<CounterPage>
           items: [
             const BottomNavigationBarItem(
                 icon: Icon(Icons.local_fire_department), label: "Kitchen"),
+            const BottomNavigationBarItem(
+                icon: Icon(Icons.store), label: "Manage"),
             const BottomNavigationBarItem(
                 icon: Icon(Icons.star_border), label: "Prestige"),
             const BottomNavigationBarItem(

--- a/lib/screens/kitchen_screen.dart
+++ b/lib/screens/kitchen_screen.dart
@@ -1,19 +1,12 @@
 import 'package:flutter/material.dart';
 import "../models/game_state.dart";
-import "../constants/panels.dart";
 import '../controllers/game_controller.dart';
-import '../models/staff.dart';
-import '../models/upgrade.dart';
 import '../util/format.dart';
-import '../widgets/upgrade_panel.dart';
-import '../widgets/staff_panel.dart';
 import '../constants/theme.dart';
 
 /// Main gameplay screen for tapping and viewing progress.
 class KitchenScreen extends StatelessWidget {
   final GameController controller;
-  final void Function(Upgrade, int) purchaseUpgrade;
-  final void Function(StaffType, int) hireStaff;
   final VoidCallback onAdReward;
   final VoidCallback onSettings;
   final Offset frenzyOffset;
@@ -21,8 +14,6 @@ class KitchenScreen extends StatelessWidget {
   const KitchenScreen({
     super.key,
     required this.controller,
-    required this.hireStaff,
-    required this.purchaseUpgrade,
     required this.onAdReward,
     required this.onSettings,
     this.frenzyOffset = Offset.zero,
@@ -37,8 +28,6 @@ class KitchenScreen extends StatelessWidget {
     final String nextName = finalStage
         ? 'Completed'
         : GameState.milestones[controller.game.milestoneIndex + 1];
-    final availableStaff =
-        staffByTier[controller.game.milestoneIndex] ?? {};
 
     return Stack(
       children: [
@@ -130,21 +119,6 @@ class KitchenScreen extends StatelessWidget {
             if (controller.adBoostActive)
               Text(
                   'Ad boost: ${(controller.adBoostSeconds ~/ 60).toString().padLeft(2, '0')}:${(controller.adBoostSeconds % 60).toString().padLeft(2, '0')}'),
-            const SizedBox(height: 16),
-            UpgradePanel(
-              upgrades: controller.upgrades,
-              currency: controller.coins,
-              onPurchase: purchaseUpgrade,
-              title: upgradePanelTitles[controller.game.milestoneIndex],
-            ),
-            const SizedBox(height: 16),
-            StaffPanel(
-              staff: availableStaff,
-              hired: controller.hiredStaff,
-              coins: controller.coins,
-              onHire: hireStaff,
-              title: hirePanelTitles[controller.game.milestoneIndex],
-            ),
             ElevatedButton(
               onPressed: onAdReward,
               child: const Text('Watch Ad for Rewards'),

--- a/lib/screens/management_screen.dart
+++ b/lib/screens/management_screen.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import '../models/upgrade.dart';
+import '../models/staff.dart';
+import '../controllers/game_controller.dart';
+import '../widgets/upgrade_panel.dart';
+import '../widgets/staff_panel.dart';
+import '../constants/panels.dart';
+
+/// Screen for purchasing upgrades and hiring staff.
+class ManagementScreen extends StatelessWidget {
+  final GameController controller;
+  final void Function(Upgrade, int) purchaseUpgrade;
+  final void Function(StaffType, int) hireStaff;
+
+  const ManagementScreen({
+    super.key,
+    required this.controller,
+    required this.purchaseUpgrade,
+    required this.hireStaff,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final availableStaff =
+        staffByTier[controller.game.milestoneIndex] ?? {};
+    return SafeArea(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            UpgradePanel(
+              upgrades: controller.upgrades,
+              currency: controller.coins,
+              onPurchase: purchaseUpgrade,
+              title: upgradePanelTitles[controller.game.milestoneIndex],
+            ),
+            const SizedBox(height: 16),
+            StaffPanel(
+              staff: availableStaff,
+              hired: controller.hiredStaff,
+              coins: controller.coins,
+              onHire: hireStaff,
+              title: hirePanelTitles[controller.game.milestoneIndex],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- move upgrades and staff to their own ManagementScreen
- hook ManagementScreen into the bottom navigation
- remove upgrade and staff panels from the kitchen screen

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68540da4fdc08321bc3296361224c2c1